### PR TITLE
Add initial quicklinks plugin and dialog.

### DIFF
--- a/components/quicklink-dialog.js
+++ b/components/quicklink-dialog.js
@@ -1,0 +1,160 @@
+import '@brightspace-ui/core/components/colors/colors.js';
+import 'tinymce/tinymce.js';
+import { css, LitElement } from 'lit-element/lit-element.js';
+import { getComposedActiveElement } from '@brightspace-ui/core/helpers/focus.js';
+import { icons } from '../icons.js';
+
+// TODO: localize the tooltip
+// TODO: resolve correct org unit id
+
+tinymce.PluginManager.add('d2l-quicklink', function(editor) {
+
+	// bail if no LMS context
+	if (!D2L.LP) return;
+
+	editor.ui.registry.addIcon('d2l-quicklink', icons['link']);
+
+	editor.ui.registry.addButton('d2l-quicklink', {
+		tooltip: 'QuickLink',
+		icon: 'd2l-quicklink',
+		onAction: () => {
+			const root = editor.getElement().getRootNode();
+
+			let dialog = root.querySelector('d2l-quicklink-dialog');
+			if (!dialog) dialog = root.appendChild(document.createElement('d2l-quicklink-dialog'));
+
+			const contextNode = (editor.selection ? editor.selection.getNode() : null);
+
+			if (contextNode && contextNode.tagName === 'A') {
+				dialog.quicklink = {
+					href: contextNode.getAttribute('href'),
+					target: contextNode.getAttribute('target'),
+					text: contextNode.innerText
+				};
+			} else {
+				dialog.text = tinymce.DOM.decode(editor.selection.getContent());
+			}
+
+			dialog.opened = true;
+			dialog.addEventListener('d2l-htmleditor-quicklink-dialog-close', (e) => {
+				const html = e.detail.html;
+				if (html) {
+					if (contextNode && contextNode.tagName === 'A') {
+						// expand selection if necessary to replace current link
+						editor.selection.select(contextNode);
+					}
+					editor.execCommand('mceInsertContent', false, html);
+				}
+			}, { once: true });
+
+		}
+	});
+
+});
+
+class QuicklinkDialog extends LitElement {
+
+	static get properties() {
+		return {
+			opened: { type: Boolean, reflect: true },
+			quicklink: { type: Object },
+			text: { type: String }
+		};
+	}
+
+	static get styles() {
+		return css`
+			:host {
+				display: block;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+		`;
+	}
+
+	constructor() {
+		super();
+		this.opened = false;
+		this.text = '';
+	}
+
+	firstUpdated(changedProperties) {
+		super.firstUpdated(changedProperties);
+	}
+
+	render() {
+	}
+
+	async updated(changedProperties) {
+		super.updated(changedProperties);
+
+		if (!changedProperties.has('opened')) return;
+
+		if (this.opened) {
+			const result = await (new Promise((resolve) => {
+
+				let selectUrl = new D2L.LP.Web.Http.UrlLocation(`/d2l/lp/quicklinks/manage/6606/createdialog?typeKey=&initialViewType=Default&outputFormat=html&selectedText=${this.text}&parentModuleId=0&canChangeType=true&showCancelButton=true&urlShowTarget=true&urlShowCancelButtonInline=false&contextId=`);
+				if (this.quicklink) selectUrl = selectUrl.WithQueryString(
+					'itemData',
+					new D2L.LP.QuickLinks.Web.Desktop.Controls.QuickLinkSelector.ItemData(
+						'',
+						null,
+						this.quicklink.href,
+						this.quicklink.text,
+						[{ name: 'target', value: (this.quicklink.target === '_top' ? 'WholeWindow' : (this.quicklink.target === '_blank' ? 'NewWindow' : 'SameFrame')) }],
+						'html'
+					)
+				);
+
+				const selectResult = D2L.LP.Web.UI.Desktop.MasterPages.Dialog.Open(
+					getComposedActiveElement(),
+					selectUrl
+				);
+
+				selectResult.AddReleaseListener(resolve);
+				selectResult.AddListener(quicklinks => {
+
+					if (!quicklinks || quicklinks.length === 0) {
+						resolve();
+						return;
+					}
+
+					const createResult = D2L.LP.Web.UI.Rpc.ConnectObject(
+						'POST',
+						new D2L.LP.Web.Http.UrlLocation('/d2l/lp/quicklinks/manage/6606/createmultiple'),
+						{ 'items': quicklinks }
+					);
+
+					createResult.AddReleaseListener(resolve);
+					createResult.AddListener(quicklinks => {
+
+						if (!quicklinks || quicklinks.length === 0) {
+							resolve();
+							return;
+						}
+
+						resolve(quicklinks.reduce((acc, cur) => {
+							return acc += cur.html;
+						}, ''));
+
+					});
+				});
+
+			}));
+
+			this.opened = false;
+
+			this.dispatchEvent(new CustomEvent(
+				'd2l-htmleditor-quicklink-dialog-close', {
+					bubbles: true,
+					detail: { html: result }
+				}
+			));
+
+		}
+
+	}
+
+}
+customElements.define('d2l-quicklink-dialog', QuicklinkDialog);

--- a/htmleditor.js
+++ b/htmleditor.js
@@ -1,3 +1,4 @@
+import './components/quicklink-dialog.js';
 import '@brightspace-ui/core/components/colors/colors.js';
 import 'tinymce/tinymce.js';
 import 'tinymce/icons/default/icons.js';
@@ -19,7 +20,7 @@ import { icons } from './icons.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { tinymceLangs } from './generated/langs.js';
 
-// To update from nre tinyMCE install
+// To update from new tinyMCE install
 // 1. copy skins from installed node_modules/tinymce into tinymce/skins
 // 2. copy new language packs from https://www.tiny.cloud/get-tiny/language-packages/ into tinymce/langs
 // 3. copy new enterprise plugins into tinymce/plugins
@@ -210,7 +211,7 @@ class HtmlEditor extends RtlMixin(LitElement) {
 				language_url: `/tinymce/langs/${tinymceLang}.js`,
 				menubar: false,
 				object_resizing : true,
-				plugins: `a11ychecker charmap code directionality ${this.fullPage ? 'fullpage' : ''} fullscreen hr lists powerpaste preview table`,
+				plugins: `a11ychecker charmap code directionality ${this.fullPage ? 'fullpage' : ''} fullscreen hr lists powerpaste preview table d2l-quicklink`,
 				relative_urls: false,
 				resize: true,
 				setup: (editor) => {
@@ -220,7 +221,7 @@ class HtmlEditor extends RtlMixin(LitElement) {
 				statusbar: true,
 				target: textarea,
 				toolbar: this.inline ? 'bold italic underline' : [
-					'bold italic underline | bullist numlist | fullscreen',
+					'bold italic underline | bullist numlist | d2l-quicklink | fullscreen',
 					'bold italic underline | styleselect fontselect fontsizeselect | forecolor a11ycheck | bullist numlist | indent outdent | alignleft alignright aligncenter alignjustify | strikethrough subscript superscript | charmap hr | table | undo redo | ltr rtl | preview code fullscreen'
 				],
 				valid_elements: '*[*]',

--- a/icons.js
+++ b/icons.js
@@ -1,6 +1,8 @@
+import { val as link } from '@brightspace-ui/core/generated/icons/html-editor/link.js';
 import { val as resizeHandle } from '@brightspace-ui/core/generated/icons/tier1/resize-right.js';
 
 const icons = {
+	'link': link,
 	'resize-handle': resizeHandle
 };
 


### PR DESCRIPTION
The module includes two distinct blocks of code that may eventually be separated.  For now, they can live in the same module.
1. the tinyMCE plugin
    - defines the button for the tinyMCE toolbar
    - logic for getting editor caret context (create vs edit)
    - launches the dialog, waits for the result, and inserts it
2. the dialog to create/edit a quicklink
    - abstracts the logic for calling into the LMS quicklinks actions (if we had quicklinks components this would internally use d2l-dialog and it would not make these LMS calls)
    - opens the LMS dialog for either creating or editing a quicklink
    - creates the quicklink once an item has been selected
    - eventually the LMS calls (launching the dialog and the RPC calls) will likely be abstracted to make this ifrau-aware

This is the sort of stuff that is going to be pretty typical for custom integrations.  We did the same logic previously, however the tinyMCE plugin part was abstracted considerably.
