### PR TITLE
Add provider mixin for orgUnitId.

### DIFF
--- a/components/quicklink-dialog.js
+++ b/components/quicklink-dialog.js
@@ -3,9 +3,11 @@ import 'tinymce/tinymce.js';
 import { css, LitElement } from 'lit-element/lit-element.js';
 import { getComposedActiveElement } from '@brightspace-ui/core/helpers/focus.js';
 import { icons } from '../icons.js';
+import { RequesterMixin } from '@brightspace-ui/core/mixins/provider-mixin.js';
 
 // TODO: localize the tooltip
-// TODO: resolve correct org unit id
+
+let orgUnitId;
 
 tinymce.PluginManager.add('d2l-quicklink', function(editor) {
 
@@ -52,7 +54,7 @@ tinymce.PluginManager.add('d2l-quicklink', function(editor) {
 
 });
 
-class QuicklinkDialog extends LitElement {
+class QuicklinkDialog extends RequesterMixin(LitElement) {
 
 	static get properties() {
 		return {
@@ -79,6 +81,11 @@ class QuicklinkDialog extends LitElement {
 		this.text = '';
 	}
 
+	connectedCallback() {
+		super.connectedCallback();
+		orgUnitId = this.requestInstance('d2l-orgUnitId');
+	}
+
 	firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);
 	}
@@ -94,7 +101,7 @@ class QuicklinkDialog extends LitElement {
 		if (this.opened) {
 			const result = await (new Promise((resolve) => {
 
-				let selectUrl = new D2L.LP.Web.Http.UrlLocation(`/d2l/lp/quicklinks/manage/6606/createdialog?typeKey=&initialViewType=Default&outputFormat=html&selectedText=${this.text}&parentModuleId=0&canChangeType=true&showCancelButton=true&urlShowTarget=true&urlShowCancelButtonInline=false&contextId=`);
+				let selectUrl = new D2L.LP.Web.Http.UrlLocation(`/d2l/lp/quicklinks/manage/${orgUnitId}/createdialog?typeKey=&initialViewType=Default&outputFormat=html&selectedText=${this.text}&parentModuleId=0&canChangeType=true&showCancelButton=true&urlShowTarget=true&urlShowCancelButtonInline=false&contextId=`);
 				if (this.quicklink) selectUrl = selectUrl.WithQueryString(
 					'itemData',
 					new D2L.LP.QuickLinks.Web.Desktop.Controls.QuickLinkSelector.ItemData(
@@ -122,7 +129,7 @@ class QuicklinkDialog extends LitElement {
 
 					const createResult = D2L.LP.Web.UI.Rpc.ConnectObject(
 						'POST',
-						new D2L.LP.Web.Http.UrlLocation('/d2l/lp/quicklinks/manage/6606/createmultiple'),
+						new D2L.LP.Web.Http.UrlLocation('/d2l/lp/quicklinks/manage/${orgUnitId}/createmultiple'),
 						{ 'items': quicklinks }
 					);
 

--- a/components/quicklink-dialog.js
+++ b/components/quicklink-dialog.js
@@ -1,4 +1,3 @@
-import '@brightspace-ui/core/components/colors/colors.js';
 import 'tinymce/tinymce.js';
 import { css, LitElement } from 'lit-element/lit-element.js';
 import { getComposedActiveElement } from '@brightspace-ui/core/helpers/focus.js';

--- a/htmleditor.js
+++ b/htmleditor.js
@@ -17,6 +17,7 @@ import 'tinymce/themes/silver/theme.js';
 import { css, html, LitElement, unsafeCSS } from 'lit-element/lit-element.js';
 import { getUniqueId } from '@brightspace-ui/core/helpers/uniqueId.js';
 import { icons } from './icons.js';
+import { ProviderMixin } from '@brightspace-ui/core/mixins/provider-mixin.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { tinymceLangs } from './generated/langs.js';
 
@@ -35,6 +36,8 @@ import { tinymceLangs } from './generated/langs.js';
 // TODO: refactor classic / inline if necessary (need Design discussion)
 // TODO: review allow_script_urls (ideally we can turn this off)
 // TODO: review auto-focus and whether it should be on the API
+
+const context = JSON.parse(document.documentElement.getAttribute('data-he-context'));
 
 const rootFontSize = window.getComputedStyle(document.documentElement, null).getPropertyValue('font-size');
 
@@ -78,7 +81,7 @@ const contentFragmentCss = css`
 	}
 `.cssText;
 
-class HtmlEditor extends RtlMixin(LitElement) {
+class HtmlEditor extends ProviderMixin(RtlMixin(LitElement)) {
 
 	static get properties() {
 		return {
@@ -139,6 +142,9 @@ class HtmlEditor extends RtlMixin(LitElement) {
 		this.width = '100%';
 		this._editorId = getUniqueId();
 		this._html = '';
+		if (context) {
+			this.provideInstance('d2l-orgUnitId', context.orgUnitId);
+		}
 	}
 
 	get html() {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "files": [
     "htmleditor.js",
     "icons.js",
+    "/components",
     "/generated",
     "/tinymce"
   ],


### PR DESCRIPTION
* reads context off the html element if present
* sets up the editor component to be a "provider"
* sets up quicklink dialog component to be a "requester" and construct urls accordingly