### PR TITLE
Fix z-index of tinyMCE sink so that it doesn't float on top of dialogs.

### DIFF
--- a/htmleditor.js
+++ b/htmleditor.js
@@ -119,35 +119,30 @@ class HtmlEditor extends ProviderMixin(RtlMixin(LitElement)) {
 			:host([hidden]) {
 				display: none;
 			}
-			/* stylelint-disable-next-line selector-class-pattern */
+			/* stylelint-disable selector-class-pattern */
 			.tox-tinymce-aux,
 			.tox-tinymce.tox-fullscreen {
 				z-index: 1000;
 			}
-			/* stylelint-disable-next-line selector-class-pattern */
 			.tox .tox-statusbar {
 				border-top: none;
 			}
-			/* stylelint-disable-next-line selector-class-pattern */
 			.tox .tox-statusbar__text-container {
 				display: none;
 			}
-			/* stylelint-disable-next-line selector-class-pattern */
 			:host([type="inline"]) .tox-tinymce .tox-toolbar-overlord > div:nth-child(2) {
 				display: none;
 			}
-			/* stylelint-disable-next-line selector-class-pattern */
 			:host([type="inline"]) .tox-tinymce.tox-fullscreen .tox-toolbar-overlord > div:nth-child(1) {
 				display: none;
 			}
-			/* stylelint-disable-next-line selector-class-pattern */
 			:host([type="inline"]) .tox-tinymce.tox-fullscreen .tox-toolbar-overlord > div:nth-child(2) {
 				display: flex;
 			}
-			/* stylelint-disable-next-line selector-class-pattern */
 			.tox-tinymce.tox-fullscreen .tox-statusbar__resize-handle {
 				display: none;
 			}
+			/* stylelint-enable selector-class-pattern */
 		`;
 	}
 

--- a/htmleditor.js
+++ b/htmleditor.js
@@ -120,8 +120,9 @@ class HtmlEditor extends ProviderMixin(RtlMixin(LitElement)) {
 				display: none;
 			}
 			/* stylelint-disable-next-line selector-class-pattern */
+			.tox-tinymce-aux,
 			.tox-tinymce.tox-fullscreen {
-				z-index: 1001;
+				z-index: 1000;
 			}
 			/* stylelint-disable-next-line selector-class-pattern */
 			.tox .tox-statusbar {


### PR DESCRIPTION
TinyMCE uses a `z-index: 1300;` to position the overflow button container.  Unfortunately this places the container on top of our dialogs.  Our dialog shim starts at `z-index: 1001;` and our dialog starts at `z-index: 1002;`.  We also need to make sure that the overflow container is positioned on top of the editor when in fullscreen mode, which uses `z-index: 1000;` because it needs to be positioned on top of things like floating workflow buttons, which uses `z-index: 999;`.  First level of z-index hell.

![image](https://user-images.githubusercontent.com/9042472/96879396-ff1a1680-1449-11eb-867a-c935c6515168.png)
