### PR TITLE
US121734 - Emit d2l-htmleditor-ready event when TinyMCE editor has finished initialization so that consumers can e.g. focus on the component once it loads

### DIFF
--- a/components/image.js
+++ b/components/image.js
@@ -66,7 +66,7 @@ export function uploadImage(editor, blobInfo, success, failure) {
 				editor._uploadImageCount--;
 				if (editor._uploadImageCount <= 0) {
 					editor.dispatchEvent(new CustomEvent(
-						'd2l-htmleditor-image-upload-finish', {
+						'd2l-htmleditor-image-upload-complete', {
 							bubbles: true
 						}
 					));

--- a/components/image.js
+++ b/components/image.js
@@ -32,7 +32,7 @@ export function uploadImage(editor, blobInfo, success, failure) {
 	editor._uploadImageCount++;
 	if (editor._uploadImageCount === 1) { // only fire the upload started event on the first image being uploaded
 		editor.dispatchEvent(new CustomEvent(
-			'd2l-htmleditor-image-upload-started', {
+			'd2l-htmleditor-image-upload-start', {
 				bubbles: true
 			}
 		));
@@ -66,7 +66,7 @@ export function uploadImage(editor, blobInfo, success, failure) {
 				editor._uploadImageCount--;
 				if (editor._uploadImageCount <= 0) {
 					editor.dispatchEvent(new CustomEvent(
-						'd2l-htmleditor-image-upload-completed', {
+						'd2l-htmleditor-image-upload-finish', {
 							bubbles: true
 						}
 					));

--- a/htmleditor.js
+++ b/htmleditor.js
@@ -202,10 +202,6 @@ class HtmlEditor extends ProviderMixin(RtlMixin(LitElement)) {
 		}
 	}
 
-	get initializationComplete() {
-		return this._initializationComplete;
-	}
-
 	firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);
 
@@ -344,6 +340,10 @@ class HtmlEditor extends ProviderMixin(RtlMixin(LitElement)) {
 
 	focus() {
 		tinymce.EditorManager.get(this._editorId).focus();
+	}
+
+	get initializationComplete() {
+		return this._initializationComplete;
 	}
 
 	_getToolbarConfig() {

--- a/htmleditor.js
+++ b/htmleditor.js
@@ -254,8 +254,15 @@ class HtmlEditor extends ProviderMixin(RtlMixin(LitElement)) {
 				images_upload_handler: (blobInfo, success, failure) => uploadImage(this, blobInfo, success, failure),
 				init_instance_callback: editor => {
 					if (editor && editor.plugins && editor.plugins.autosave) {
-						delete editor.plugins.autosave; // removing the autosave plugin prevents saving of content but retains the "ask_before_unload" behaviour
+						// removing the autosave plugin prevents saving of content but retains the "ask_before_unload" behaviour
+						delete editor.plugins.autosave;
 					}
+
+					this.dispatchEvent(new CustomEvent(
+						'd2l-htmleditor-ready', {
+							bubbles: true
+						}
+					));
 				},
 				// inline: this.type === editorTypes.INLINE || this.type === editorTypes.INLINE_LIMITED,
 				language: tinymceLang,

--- a/htmleditor.js
+++ b/htmleditor.js
@@ -162,6 +162,9 @@ class HtmlEditor extends ProviderMixin(RtlMixin(LitElement)) {
 		this.width = '100%';
 		this._editorId = getUniqueId();
 		this._html = '';
+		this._initializationComplete = new Promise((resolve) => {
+			this._initializationResolve = resolve;
+		});
 		this._uploadImageCount = 0;
 		if (context) {
 			this.provideInstance('maxFileSize', context.maxFileSize);
@@ -197,6 +200,10 @@ class HtmlEditor extends ProviderMixin(RtlMixin(LitElement)) {
 			}
 			this.requestUpdate('html', oldVal);
 		}
+	}
+
+	get initializationComplete() {
+		return this._initializationComplete;
 	}
 
 	firstUpdated(changedProperties) {
@@ -258,11 +265,7 @@ class HtmlEditor extends ProviderMixin(RtlMixin(LitElement)) {
 						delete editor.plugins.autosave;
 					}
 
-					this.dispatchEvent(new CustomEvent(
-						'd2l-htmleditor-ready', {
-							bubbles: true
-						}
-					));
+					this._initializationResolve();
 				},
 				// inline: this.type === editorTypes.INLINE || this.type === editorTypes.INLINE_LIMITED,
 				language: tinymceLang,


### PR DESCRIPTION
Associated Rally ticket: [US121734](https://rally1.rallydev.com/#/detail/userstory/448887517928?fdp=true)

Two main things here:
1. Rename existing PowerPaste-specific events to follow best practice.
2. Emit a `d2l-htmleditor-ready` event when TinyMCE is done initializing so consumers can hook into the editor on load.