### PR TITLE
US122296 - Allow localization of D2L-specific lang terms in HTML editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules/
 package-lock.json
 test/screenshots/current/
 test/screenshots/golden/
+debug.log
+npm-debug.log

--- a/components/equation.js
+++ b/components/equation.js
@@ -65,7 +65,7 @@ tinymce.PluginManager.add('d2l-equation', function(editor) {
 
 	editor.ui.registry.addSplitButton('d2l-equation', {
 		icon: 'd2l-equation-graphical',
-		tooltip: localize('htmleditor.equationeditor.graphicaltooltip'),
+		tooltip: localize('equationeditor.graphicaltooltip'),
 		onAction: () => {
 			launchEditor(editorTypes.Graphical);
 		},
@@ -80,25 +80,25 @@ tinymce.PluginManager.add('d2l-equation', function(editor) {
 			callback([{
 				type: 'choiceitem',
 				icon: 'd2l-equation-graphical',
-				text: localize('htmleditor.equationeditor.graphicaltooltip'),
+				text: localize('equationeditor.graphicaltooltip'),
 				value: editorTypes.Graphical,
 				disabled: contextNode && editorType !== editorTypes.Graphical
 			}, {
 				type: 'choiceitem',
 				icon: 'd2l-equation-latex',
-				text: localize('htmleditor.equationeditor.latextooltip'),
+				text: localize('equationeditor.latextooltip'),
 				value: editorTypes.Latex,
 				disabled: contextNode && editorType !== editorTypes.Latex
 			}, {
 				type: 'choiceitem',
 				icon: 'd2l-equation-mathml',
-				text: localize('htmleditor.equationeditor.mathmltooltip'),
+				text: localize('equationeditor.mathmltooltip'),
 				value: editorTypes.MathML,
 				disabled: contextNode && editorType !== editorTypes.MathML
 			}, {
 				type: 'choiceitem',
 				icon: 'd2l-equation-chemistry',
-				text: localize('htmleditor.equationeditor.chemistrytooltip'),
+				text: localize('equationeditor.chemistrytooltip'),
 				value: editorTypes.Chemistry,
 				disabled: contextNode && editorType !== editorTypes.Chemistry
 			}]);

--- a/components/equation.js
+++ b/components/equation.js
@@ -3,8 +3,7 @@
 import { css, LitElement } from 'lit-element/lit-element.js';
 import { getComposedActiveElement } from '@brightspace-ui/core/helpers/focus.js';
 import { icons } from '../icons.js';
-
-// TODO: localize the tooltip
+import { requestInstance } from '@brightspace-ui/core/mixins/provider-mixin.js';
 
 const editorTypes = {
 	Latex: 0,
@@ -17,6 +16,8 @@ tinymce.PluginManager.add('d2l-equation', function(editor) {
 
 	// bail if no LMS context
 	if (!D2L.LP) return;
+
+	const localize = requestInstance(editor.getElement(), 'localize');
 
 	editor.ui.registry.addIcon('d2l-equation-chemistry', icons['equation-chemistry']);
 	editor.ui.registry.addIcon('d2l-equation-graphical', icons['equation-graphical']);
@@ -64,7 +65,7 @@ tinymce.PluginManager.add('d2l-equation', function(editor) {
 
 	editor.ui.registry.addSplitButton('d2l-equation', {
 		icon: 'd2l-equation-graphical',
-		tooltip: 'Equations',
+		tooltip: localize('htmleditor.equationeditor.graphicaltooltip'),
 		onAction: () => {
 			launchEditor(editorTypes.Graphical);
 		},
@@ -79,25 +80,25 @@ tinymce.PluginManager.add('d2l-equation', function(editor) {
 			callback([{
 				type: 'choiceitem',
 				icon: 'd2l-equation-graphical',
-				text: 'Graphical Equation',
+				text: localize('htmleditor.equationeditor.graphicaltooltip'),
 				value: editorTypes.Graphical,
 				disabled: contextNode && editorType !== editorTypes.Graphical
 			}, {
 				type: 'choiceitem',
 				icon: 'd2l-equation-latex',
-				text: 'LaTeX Equation',
+				text: localize('htmleditor.equationeditor.latextooltip'),
 				value: editorTypes.Latex,
 				disabled: contextNode && editorType !== editorTypes.Latex
 			}, {
 				type: 'choiceitem',
 				icon: 'd2l-equation-mathml',
-				text: 'MathML Equation',
+				text: localize('htmleditor.equationeditor.mathmltooltip'),
 				value: editorTypes.MathML,
 				disabled: contextNode && editorType !== editorTypes.MathML
 			}, {
 				type: 'choiceitem',
 				icon: 'd2l-equation-chemistry',
-				text: 'Chemistry Equation',
+				text: localize('htmleditor.equationeditor.chemistrytooltip'),
 				value: editorTypes.Chemistry,
 				disabled: contextNode && editorType !== editorTypes.Chemistry
 			}]);

--- a/components/image.js
+++ b/components/image.js
@@ -4,8 +4,6 @@ import { RequesterMixin, requestInstance } from '@brightspace-ui/core/mixins/pro
 import { getComposedActiveElement } from '@brightspace-ui/core/helpers/focus.js';
 import { icons } from '../icons.js';
 
-// TODO: localize the tooltip
-
 const fileTypes = {
 	All: 0,
 	Image: 1
@@ -85,10 +83,12 @@ tinymce.PluginManager.add('d2l-image', function(editor) {
 	// bail if no LMS context
 	if (!D2L.LP) return;
 
+	const localize = requestInstance(editor.getElement(), 'localize');
+
 	editor.ui.registry.addIcon('d2l-image', icons['image']);
 
 	editor.ui.registry.addButton('d2l-image', {
-		tooltip: 'Insert Image',
+		tooltip: localize('htmleditor.image.tooltip'),
 		icon: 'd2l-image',
 		onAction: () => {
 			const root = editor.getElement().getRootNode();

--- a/components/image.js
+++ b/components/image.js
@@ -88,7 +88,7 @@ tinymce.PluginManager.add('d2l-image', function(editor) {
 	editor.ui.registry.addIcon('d2l-image', icons['image']);
 
 	editor.ui.registry.addButton('d2l-image', {
-		tooltip: localize('htmleditor.image.tooltip'),
+		tooltip: localize('image.tooltip'),
 		icon: 'd2l-image',
 		onAction: () => {
 			const root = editor.getElement().getRootNode();

--- a/components/isf.js
+++ b/components/isf.js
@@ -4,8 +4,6 @@ import { RequesterMixin, requestInstance } from '@brightspace-ui/core/mixins/pro
 import { getComposedActiveElement } from '@brightspace-ui/core/helpers/focus.js';
 import { icons } from '../icons.js';
 
-// TODO: localize the tooltip
-
 export const isfStyles = css`
 	/* stylelint-disable-next-line selector-class-pattern */
 	.disf_default, .disf_flash, .disf_shockwave, .disf_quicktime, .disf_windowsmedia, .disf_realmedia {
@@ -30,12 +28,13 @@ tinymce.PluginManager.add('d2l-isf', function(editor) {
 	// bail if no LMS context
 	if (!D2L.LP) return;
 
+	const localize = requestInstance(editor.getElement(), 'localize');
 	const wmodeOpaque = requestInstance(editor.getElement(), 'wmodeOpaque');
 
 	editor.ui.registry.addIcon('d2l-isf', icons['media']);
 
 	editor.ui.registry.addButton('d2l-isf', {
-		tooltip: 'Insert Stuff',
+		tooltip: localize('htmleditor.insertstuff.tooltip'),
 		icon: 'd2l-isf',
 		onAction: () => {
 			const root = editor.getElement().getRootNode();

--- a/components/isf.js
+++ b/components/isf.js
@@ -34,7 +34,7 @@ tinymce.PluginManager.add('d2l-isf', function(editor) {
 	editor.ui.registry.addIcon('d2l-isf', icons['media']);
 
 	editor.ui.registry.addButton('d2l-isf', {
-		tooltip: localize('htmleditor.insertstuff.tooltip'),
+		tooltip: localize('insertstuff.tooltip'),
 		icon: 'd2l-isf',
 		onAction: () => {
 			const root = editor.getElement().getRootNode();

--- a/components/preview.js
+++ b/components/preview.js
@@ -2,17 +2,16 @@ import 'tinymce/tinymce.js';
 import { css, LitElement } from 'lit-element/lit-element.js';
 import { RequesterMixin, requestInstance } from '@brightspace-ui/core/mixins/provider-mixin.js';
 
-// TODO: localize the tooltip
-
 tinymce.PluginManager.add('d2l-preview', function(editor) {
 
 	// bail if no LMS context
 	if (!D2L.LP) return;
 
+	const localize = requestInstance(editor.getElement(), 'localize');
 	const orgUnitId = requestInstance(editor.getElement(), 'orgUnitId');
 
 	editor.ui.registry.addButton('d2l-preview', {
-		tooltip: 'Preview',
+		tooltip: localize('htmleditor.preview.tooltip'),
 		icon: 'preview',
 		onAction: () => {
 			const root = editor.getElement().getRootNode();

--- a/components/preview.js
+++ b/components/preview.js
@@ -11,7 +11,7 @@ tinymce.PluginManager.add('d2l-preview', function(editor) {
 	const orgUnitId = requestInstance(editor.getElement(), 'orgUnitId');
 
 	editor.ui.registry.addButton('d2l-preview', {
-		tooltip: localize('htmleditor.preview.tooltip'),
+		tooltip: localize('preview.tooltip'),
 		icon: 'preview',
 		onAction: () => {
 			const root = editor.getElement().getRootNode();

--- a/components/quicklink.js
+++ b/components/quicklink.js
@@ -1,20 +1,20 @@
 import 'tinymce/tinymce.js';
 import { css, LitElement } from 'lit-element/lit-element.js';
+import { RequesterMixin, requestInstance } from '@brightspace-ui/core/mixins/provider-mixin.js';
 import { getComposedActiveElement } from '@brightspace-ui/core/helpers/focus.js';
 import { icons } from '../icons.js';
-import { RequesterMixin } from '@brightspace-ui/core/mixins/provider-mixin.js';
-
-// TODO: localize the tooltip
 
 tinymce.PluginManager.add('d2l-quicklink', function(editor) {
 
 	// bail if no LMS context
 	if (!D2L.LP) return;
 
+	const localize = requestInstance(editor.getElement(), 'localize');
+
 	editor.ui.registry.addIcon('d2l-quicklink', icons['link']);
 
 	editor.ui.registry.addButton('d2l-quicklink', {
-		tooltip: 'Insert QuickLink',
+		tooltip: localize('htmleditor.quicklink.tooltip'),
 		icon: 'd2l-quicklink',
 		onAction: () => {
 			const root = editor.getElement().getRootNode();

--- a/components/quicklink.js
+++ b/components/quicklink.js
@@ -14,7 +14,7 @@ tinymce.PluginManager.add('d2l-quicklink', function(editor) {
 	editor.ui.registry.addIcon('d2l-quicklink', icons['link']);
 
 	editor.ui.registry.addButton('d2l-quicklink', {
-		tooltip: localize('htmleditor.quicklink.tooltip'),
+		tooltip: localize('quicklink.tooltip'),
 		icon: 'd2l-quicklink',
 		onAction: () => {
 			const root = editor.getElement().getRootNode();

--- a/htmleditor.js
+++ b/htmleditor.js
@@ -22,6 +22,7 @@ import { css, html, LitElement, unsafeCSS } from 'lit-element/lit-element.js';
 import { getUniqueId } from '@brightspace-ui/core/helpers/uniqueId.js';
 import { icons } from './icons.js';
 import { isfStyles } from './components/isf.js';
+import { Localizer } from './lang/localizer.js';
 import { ProviderMixin } from '@brightspace-ui/core/mixins/provider-mixin.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { tinymceLangs } from './generated/langs.js';
@@ -32,7 +33,6 @@ import { uploadImage } from './components/image.js';
 // 2. copy new language packs from https://www.tiny.cloud/get-tiny/language-packages/ into tinymce/langs
 // 3. copy new enterprise plugins into tinymce/plugins
 
-// TODO: set powerpaste_word_import based on paste formatting config value (clean, merge, prompt)
 // TODO: review whether pasted content needs prepcessing to avoid pasted image links getting converted to images
 // TODO: configure paste_as_text if using tinyMCEs paste as text feature (fra editor sets to false if power paste enabled) - probably not needed
 // TODO: review whether we need to stop pasting of image addresses (see fra editor)
@@ -89,7 +89,7 @@ const contentFragmentStyles = css`
 	}
 `.cssText;
 
-class HtmlEditor extends ProviderMixin(RtlMixin(LitElement)) {
+class HtmlEditor extends ProviderMixin(Localizer(RtlMixin(LitElement))) {
 
 	static get properties() {
 		return {
@@ -127,9 +127,6 @@ class HtmlEditor extends ProviderMixin(RtlMixin(LitElement)) {
 			}
 			.tox .tox-statusbar {
 				border-top: none;
-			}
-			.tox .tox-statusbar__text-container {
-				display: none;
 			}
 			:host([type="inline"]) .tox-tinymce .tox-toolbar-overlord > div:nth-child(2) {
 				display: none;
@@ -181,6 +178,7 @@ class HtmlEditor extends ProviderMixin(RtlMixin(LitElement)) {
 			this.provideInstance('fullPage', this.fullPage);
 			this.provideInstance('noFilter', this.noFilter);
 		}, 0);
+		this.provideInstance('localize', this.localize.bind(this));
 	}
 
 	get html() {
@@ -247,6 +245,7 @@ class HtmlEditor extends ProviderMixin(RtlMixin(LitElement)) {
 				content_css: `${baseImportPath}/tinymce/skins/content/default/content.css`,
 				content_style: this.fullPage ? isfStyles : `${contentFragmentStyles} ${isfStyles}`,
 				directionality: this.dir ? this.dir : 'ltr',
+				elementpath: false,
 				extended_valid_elements: 'span[*]',
 				external_plugins: {
 					'a11ychecker': `${baseImportPath}/tinymce/plugins/a11ychecker/plugin.js`,
@@ -267,7 +266,7 @@ class HtmlEditor extends ProviderMixin(RtlMixin(LitElement)) {
 				},
 				// inline: this.type === editorTypes.INLINE || this.type === editorTypes.INLINE_LIMITED,
 				language: tinymceLang,
-				language_url: `/tinymce/langs/${tinymceLang}.js`,
+				language_url: `${baseImportPath}/tinymce/langs/${tinymceLang}.js`,
 				menubar: false,
 				object_resizing : true,
 				plugins: `a11ychecker ${this.autoSave ? 'autosave' : ''} charmap advcode directionality emoticons ${this.fullPage ? 'fullpage' : ''} fullscreen hr image ${this.pasteLocalImages ? 'imagetools' : ''} lists powerpaste ${D2L.LP ? 'd2l-preview' : 'preview'}  table d2l-equation d2l-image d2l-isf d2l-quicklink`,

--- a/htmleditor.serge.json
+++ b/htmleditor.serge.json
@@ -1,0 +1,27 @@
+{
+    "name": "htmleditor",
+    "parser_plugin": {
+      "plugin": "parse_js"
+    },
+    "source_match": "en\\.js$",
+    "source_dir": "lang",
+    "output_file_path": "lang/%LANG%.js",
+    "output_lang_rewrite": [
+      "ar-sa ar",
+      "cy-gb cy",
+      "da-dk da",
+      "de-de de",
+      "es-es es-es",
+      "es-mx es",
+      "fr-ca fr",
+      "fr-fr fr-fr",
+      "ja-jp ja",
+      "ko-kr ko",
+      "nl-nl nl",
+      "pt-br pt",
+      "sv-se sv",
+      "tr-tr tr",
+      "zh-cn zh",
+      "zh-tw zh-tw"
+    ]
+  }

--- a/lang/ar.js
+++ b/lang/ar.js
@@ -1,12 +1,12 @@
 /* eslint quotes: 0 */
 
 export default {
-	"htmleditor.equationeditor.chemistrytooltip": "معادلة في الكيمياء",
-	"htmleditor.equationeditor.graphicaltooltip": "معادلة رسومية",
-	"htmleditor.equationeditor.latextooltip": "معادلة LaTeX",
-	"htmleditor.equationeditor.mathmltooltip": "معادلة MathML",
-	"htmleditor.image.tooltip": "إدراج صورة",
-	"htmleditor.insertstuff.tooltip": "إدراج الأغراض",
-	"htmleditor.preview.tooltip": "معاينة",
-	"htmleditor.quicklink.tooltip": "إدراج ارتباط سريع"
+	"equationeditor.chemistrytooltip": "معادلة في الكيمياء",
+	"equationeditor.graphicaltooltip": "معادلة رسومية",
+	"equationeditor.latextooltip": "معادلة LaTeX",
+	"equationeditor.mathmltooltip": "معادلة MathML",
+	"image.tooltip": "إدراج صورة",
+	"insertstuff.tooltip": "إدراج الأغراض",
+	"preview.tooltip": "معاينة",
+	"quicklink.tooltip": "إدراج ارتباط سريع"
 };

--- a/lang/ar.js
+++ b/lang/ar.js
@@ -1,0 +1,12 @@
+/* eslint quotes: 0 */
+
+export default {
+	"htmleditor.equationeditor.chemistrytooltip": "معادلة في الكيمياء",
+	"htmleditor.equationeditor.graphicaltooltip": "معادلة رسومية",
+	"htmleditor.equationeditor.latextooltip": "معادلة LaTeX",
+	"htmleditor.equationeditor.mathmltooltip": "معادلة MathML",
+	"htmleditor.image.tooltip": "إدراج صورة",
+	"htmleditor.insertstuff.tooltip": "إدراج الأغراض",
+	"htmleditor.preview.tooltip": "معاينة",
+	"htmleditor.quicklink.tooltip": "إدراج ارتباط سريع"
+};

--- a/lang/cy.js
+++ b/lang/cy.js
@@ -1,12 +1,12 @@
 /* eslint quotes: 0 */
 
 export default {
-	"htmleditor.equationeditor.chemistrytooltip": "Hafaliad cemeg",
-	"htmleditor.equationeditor.graphicaltooltip": "Hafaliad graffigol",
-	"htmleditor.equationeditor.latextooltip": "Hafaliad LaTeX",
-	"htmleditor.equationeditor.mathmltooltip": "Hafaliad MathML",
-	"htmleditor.image.tooltip": "Mewnosod Delwedd",
-	"htmleditor.insertstuff.tooltip": "Mewnosod Stwff",
-	"htmleditor.preview.tooltip": "Rhagolwg",
-	"htmleditor.quicklink.tooltip": "Mewnosod Dolen Sydyn"
+	"equationeditor.chemistrytooltip": "Hafaliad cemeg",
+	"equationeditor.graphicaltooltip": "Hafaliad graffigol",
+	"equationeditor.latextooltip": "Hafaliad LaTeX",
+	"equationeditor.mathmltooltip": "Hafaliad MathML",
+	"image.tooltip": "Mewnosod Delwedd",
+	"insertstuff.tooltip": "Mewnosod Stwff",
+	"preview.tooltip": "Rhagolwg",
+	"quicklink.tooltip": "Mewnosod Dolen Sydyn"
 };

--- a/lang/cy.js
+++ b/lang/cy.js
@@ -1,0 +1,12 @@
+/* eslint quotes: 0 */
+
+export default {
+	"htmleditor.equationeditor.chemistrytooltip": "Hafaliad cemeg",
+	"htmleditor.equationeditor.graphicaltooltip": "Hafaliad graffigol",
+	"htmleditor.equationeditor.latextooltip": "Hafaliad LaTeX",
+	"htmleditor.equationeditor.mathmltooltip": "Hafaliad MathML",
+	"htmleditor.image.tooltip": "Mewnosod Delwedd",
+	"htmleditor.insertstuff.tooltip": "Mewnosod Stwff",
+	"htmleditor.preview.tooltip": "Rhagolwg",
+	"htmleditor.quicklink.tooltip": "Mewnosod Dolen Sydyn"
+};

--- a/lang/da.js
+++ b/lang/da.js
@@ -1,12 +1,12 @@
 /* eslint quotes: 0 */
 
 export default {
-	"htmleditor.equationeditor.chemistrytooltip": "Kemisk ligning",
-	"htmleditor.equationeditor.graphicaltooltip": "Grafisk ligning",
-	"htmleditor.equationeditor.latextooltip": "LaTeX-ligning",
-	"htmleditor.equationeditor.mathmltooltip": "MathML-ligning",
-	"htmleditor.image.tooltip": "Indsæt billede",
-	"htmleditor.insertstuff.tooltip": "Indsæt ting",
-	"htmleditor.preview.tooltip": "Forhåndsvisning",
-	"htmleditor.quicklink.tooltip": "Indsæt genvejslink"
+	"equationeditor.chemistrytooltip": "Kemisk ligning",
+	"equationeditor.graphicaltooltip": "Grafisk ligning",
+	"equationeditor.latextooltip": "LaTeX-ligning",
+	"equationeditor.mathmltooltip": "MathML-ligning",
+	"image.tooltip": "Indsæt billede",
+	"insertstuff.tooltip": "Indsæt ting",
+	"preview.tooltip": "Forhåndsvisning",
+	"quicklink.tooltip": "Indsæt genvejslink"
 };

--- a/lang/da.js
+++ b/lang/da.js
@@ -1,0 +1,12 @@
+/* eslint quotes: 0 */
+
+export default {
+	"htmleditor.equationeditor.chemistrytooltip": "Kemisk ligning",
+	"htmleditor.equationeditor.graphicaltooltip": "Grafisk ligning",
+	"htmleditor.equationeditor.latextooltip": "LaTeX-ligning",
+	"htmleditor.equationeditor.mathmltooltip": "MathML-ligning",
+	"htmleditor.image.tooltip": "Indsæt billede",
+	"htmleditor.insertstuff.tooltip": "Indsæt ting",
+	"htmleditor.preview.tooltip": "Forhåndsvisning",
+	"htmleditor.quicklink.tooltip": "Indsæt genvejslink"
+};

--- a/lang/de.js
+++ b/lang/de.js
@@ -1,12 +1,12 @@
 /* eslint quotes: 0 */
 
 export default {
-	"htmleditor.equationeditor.chemistrytooltip": "Chemische Gleichung",
-	"htmleditor.equationeditor.graphicaltooltip": "Grafische Formel",
-	"htmleditor.equationeditor.latextooltip": "LaTeX-Formel",
-	"htmleditor.equationeditor.mathmltooltip": "MathML-Formel",
-	"htmleditor.image.tooltip": "Bild einfügen",
-	"htmleditor.insertstuff.tooltip": "Elemente einfügen",
-	"htmleditor.preview.tooltip": "Vorschau",
-	"htmleditor.quicklink.tooltip": "QuickLink einfügen"
+	"equationeditor.chemistrytooltip": "Chemische Gleichung",
+	"equationeditor.graphicaltooltip": "Grafische Formel",
+	"equationeditor.latextooltip": "LaTeX-Formel",
+	"equationeditor.mathmltooltip": "MathML-Formel",
+	"image.tooltip": "Bild einfügen",
+	"insertstuff.tooltip": "Elemente einfügen",
+	"preview.tooltip": "Vorschau",
+	"quicklink.tooltip": "QuickLink einfügen"
 };

--- a/lang/de.js
+++ b/lang/de.js
@@ -1,0 +1,12 @@
+/* eslint quotes: 0 */
+
+export default {
+	"htmleditor.equationeditor.chemistrytooltip": "Chemische Gleichung",
+	"htmleditor.equationeditor.graphicaltooltip": "Grafische Formel",
+	"htmleditor.equationeditor.latextooltip": "LaTeX-Formel",
+	"htmleditor.equationeditor.mathmltooltip": "MathML-Formel",
+	"htmleditor.image.tooltip": "Bild einfügen",
+	"htmleditor.insertstuff.tooltip": "Elemente einfügen",
+	"htmleditor.preview.tooltip": "Vorschau",
+	"htmleditor.quicklink.tooltip": "QuickLink einfügen"
+};

--- a/lang/en.js
+++ b/lang/en.js
@@ -1,0 +1,12 @@
+/* eslint quotes: 0 */
+
+export default {
+	"htmleditor.equationeditor.chemistrytooltip": "Chemistry Equation",
+	"htmleditor.equationeditor.graphicaltooltip": "Graphical Equation",
+	"htmleditor.equationeditor.latextooltip": "LaTeX Equation",
+	"htmleditor.equationeditor.mathmltooltip": "MathML Equation",
+	"htmleditor.image.tooltip": "Insert Image",
+	"htmleditor.insertstuff.tooltip": "Insert Stuff",
+	"htmleditor.preview.tooltip": "Preview",
+	"htmleditor.quicklink.tooltip": "Insert Quicklink"
+};

--- a/lang/en.js
+++ b/lang/en.js
@@ -1,12 +1,12 @@
 /* eslint quotes: 0 */
 
 export default {
-	"htmleditor.equationeditor.chemistrytooltip": "Chemistry Equation",
-	"htmleditor.equationeditor.graphicaltooltip": "Graphical Equation",
-	"htmleditor.equationeditor.latextooltip": "LaTeX Equation",
-	"htmleditor.equationeditor.mathmltooltip": "MathML Equation",
-	"htmleditor.image.tooltip": "Insert Image",
-	"htmleditor.insertstuff.tooltip": "Insert Stuff",
-	"htmleditor.preview.tooltip": "Preview",
-	"htmleditor.quicklink.tooltip": "Insert Quicklink"
+	"equationeditor.chemistrytooltip": "Chemistry Equation",
+	"equationeditor.graphicaltooltip": "Graphical Equation",
+	"equationeditor.latextooltip": "LaTeX Equation",
+	"equationeditor.mathmltooltip": "MathML Equation",
+	"image.tooltip": "Insert Image",
+	"insertstuff.tooltip": "Insert Stuff",
+	"preview.tooltip": "Preview",
+	"quicklink.tooltip": "Insert Quicklink"
 };

--- a/lang/es-es.js
+++ b/lang/es-es.js
@@ -1,12 +1,12 @@
 /* eslint quotes: 0 */
 
 export default {
-	"htmleditor.equationeditor.chemistrytooltip": "Ecuación química",
-	"htmleditor.equationeditor.graphicaltooltip": "Ecuación gráfica",
-	"htmleditor.equationeditor.latextooltip": "Ecuación de LaTeX",
-	"htmleditor.equationeditor.mathmltooltip": "Ecuación de MathML",
-	"htmleditor.image.tooltip": "Insertar imagen",
-	"htmleditor.insertstuff.tooltip": "Insertar recursos",
-	"htmleditor.preview.tooltip": "Vista previa",
-	"htmleditor.quicklink.tooltip": "Insertar enlace rápido"
+	"equationeditor.chemistrytooltip": "Ecuación química",
+	"equationeditor.graphicaltooltip": "Ecuación gráfica",
+	"equationeditor.latextooltip": "Ecuación de LaTeX",
+	"equationeditor.mathmltooltip": "Ecuación de MathML",
+	"image.tooltip": "Insertar imagen",
+	"insertstuff.tooltip": "Insertar recursos",
+	"preview.tooltip": "Vista previa",
+	"quicklink.tooltip": "Insertar enlace rápido"
 };

--- a/lang/es-es.js
+++ b/lang/es-es.js
@@ -1,0 +1,12 @@
+/* eslint quotes: 0 */
+
+export default {
+	"htmleditor.equationeditor.chemistrytooltip": "Ecuación química",
+	"htmleditor.equationeditor.graphicaltooltip": "Ecuación gráfica",
+	"htmleditor.equationeditor.latextooltip": "Ecuación de LaTeX",
+	"htmleditor.equationeditor.mathmltooltip": "Ecuación de MathML",
+	"htmleditor.image.tooltip": "Insertar imagen",
+	"htmleditor.insertstuff.tooltip": "Insertar recursos",
+	"htmleditor.preview.tooltip": "Vista previa",
+	"htmleditor.quicklink.tooltip": "Insertar enlace rápido"
+};

--- a/lang/es.js
+++ b/lang/es.js
@@ -1,12 +1,12 @@
 /* eslint quotes: 0 */
 
 export default {
-	"htmleditor.equationeditor.chemistrytooltip": "Ecuación química",
-	"htmleditor.equationeditor.graphicaltooltip": "Ecuación gráfica",
-	"htmleditor.equationeditor.latextooltip": "Ecuación de LaTeX",
-	"htmleditor.equationeditor.mathmltooltip": "Ecuación de MathML",
-	"htmleditor.image.tooltip": "Insertar imagen",
-	"htmleditor.insertstuff.tooltip": "Insertar recursos",
-	"htmleditor.preview.tooltip": "Vista previa",
-	"htmleditor.quicklink.tooltip": "Insertar enlace rápido"
+	"equationeditor.chemistrytooltip": "Ecuación química",
+	"equationeditor.graphicaltooltip": "Ecuación gráfica",
+	"equationeditor.latextooltip": "Ecuación de LaTeX",
+	"equationeditor.mathmltooltip": "Ecuación de MathML",
+	"image.tooltip": "Insertar imagen",
+	"insertstuff.tooltip": "Insertar recursos",
+	"preview.tooltip": "Vista previa",
+	"quicklink.tooltip": "Insertar enlace rápido"
 };

--- a/lang/es.js
+++ b/lang/es.js
@@ -1,0 +1,12 @@
+/* eslint quotes: 0 */
+
+export default {
+	"htmleditor.equationeditor.chemistrytooltip": "Ecuación química",
+	"htmleditor.equationeditor.graphicaltooltip": "Ecuación gráfica",
+	"htmleditor.equationeditor.latextooltip": "Ecuación de LaTeX",
+	"htmleditor.equationeditor.mathmltooltip": "Ecuación de MathML",
+	"htmleditor.image.tooltip": "Insertar imagen",
+	"htmleditor.insertstuff.tooltip": "Insertar recursos",
+	"htmleditor.preview.tooltip": "Vista previa",
+	"htmleditor.quicklink.tooltip": "Insertar enlace rápido"
+};

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -1,12 +1,12 @@
 /* eslint quotes: 0 */
 
 export default {
-	"htmleditor.equationeditor.chemistrytooltip": "Équation de chimie",
-	"htmleditor.equationeditor.graphicaltooltip": "Équation graphique",
-	"htmleditor.equationeditor.latextooltip": "Équation de LaTeX",
-	"htmleditor.equationeditor.mathmltooltip": "Équation MathML",
-	"htmleditor.image.tooltip": "Insérer une image",
-	"htmleditor.insertstuff.tooltip": "Insérer quelque chose",
-	"htmleditor.preview.tooltip": "Prévisualiser",
-	"htmleditor.quicklink.tooltip": "Ajouter un Lien rapide"
+	"equationeditor.chemistrytooltip": "Équation de chimie",
+	"equationeditor.graphicaltooltip": "Équation graphique",
+	"equationeditor.latextooltip": "Équation de LaTeX",
+	"equationeditor.mathmltooltip": "Équation MathML",
+	"image.tooltip": "Insérer une image",
+	"insertstuff.tooltip": "Insérer quelque chose",
+	"preview.tooltip": "Prévisualiser",
+	"quicklink.tooltip": "Ajouter un Lien rapide"
 };

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -1,0 +1,12 @@
+/* eslint quotes: 0 */
+
+export default {
+	"htmleditor.equationeditor.chemistrytooltip": "Équation de chimie",
+	"htmleditor.equationeditor.graphicaltooltip": "Équation graphique",
+	"htmleditor.equationeditor.latextooltip": "Équation de LaTeX",
+	"htmleditor.equationeditor.mathmltooltip": "Équation MathML",
+	"htmleditor.image.tooltip": "Insérer une image",
+	"htmleditor.insertstuff.tooltip": "Insérer quelque chose",
+	"htmleditor.preview.tooltip": "Prévisualiser",
+	"htmleditor.quicklink.tooltip": "Ajouter un Lien rapide"
+};

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -1,12 +1,12 @@
 /* eslint quotes: 0 */
 
 export default {
-	"htmleditor.equationeditor.chemistrytooltip": "Équation chimique",
-	"htmleditor.equationeditor.graphicaltooltip": "Équation graphique",
-	"htmleditor.equationeditor.latextooltip": "Équation de LaTeX",
-	"htmleditor.equationeditor.mathmltooltip": "Équation de MathML",
-	"htmleditor.image.tooltip": "Insérer l’image",
-	"htmleditor.insertstuff.tooltip": "Insérer le symbole",
-	"htmleditor.preview.tooltip": "Prévisualiser",
-	"htmleditor.quicklink.tooltip": "Insérer le lien rapide"
+	"equationeditor.chemistrytooltip": "Équation chimique",
+	"equationeditor.graphicaltooltip": "Équation graphique",
+	"equationeditor.latextooltip": "Équation de LaTeX",
+	"equationeditor.mathmltooltip": "Équation de MathML",
+	"image.tooltip": "Insérer l’image",
+	"insertstuff.tooltip": "Insérer le symbole",
+	"preview.tooltip": "Prévisualiser",
+	"quicklink.tooltip": "Insérer le lien rapide"
 };

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -1,0 +1,12 @@
+/* eslint quotes: 0 */
+
+export default {
+	"htmleditor.equationeditor.chemistrytooltip": "Équation chimique",
+	"htmleditor.equationeditor.graphicaltooltip": "Équation graphique",
+	"htmleditor.equationeditor.latextooltip": "Équation de LaTeX",
+	"htmleditor.equationeditor.mathmltooltip": "Équation de MathML",
+	"htmleditor.image.tooltip": "Insérer l’image",
+	"htmleditor.insertstuff.tooltip": "Insérer le symbole",
+	"htmleditor.preview.tooltip": "Prévisualiser",
+	"htmleditor.quicklink.tooltip": "Insérer le lien rapide"
+};

--- a/lang/ja.js
+++ b/lang/ja.js
@@ -1,12 +1,12 @@
 /* eslint quotes: 0 */
 
 export default {
-	"htmleditor.equationeditor.chemistrytooltip": "化学方程式",
-	"htmleditor.equationeditor.graphicaltooltip": "グラフィカル数式",
-	"htmleditor.equationeditor.latextooltip": "LaTeX 数式",
-	"htmleditor.equationeditor.mathmltooltip": "MathML 数式",
-	"htmleditor.image.tooltip": "イメージの挿入",
-	"htmleditor.insertstuff.tooltip": "素材の挿入",
-	"htmleditor.preview.tooltip": "プレビュー",
-	"htmleditor.quicklink.tooltip": "クイックリンクの挿入"
+	"equationeditor.chemistrytooltip": "化学方程式",
+	"equationeditor.graphicaltooltip": "グラフィカル数式",
+	"equationeditor.latextooltip": "LaTeX 数式",
+	"equationeditor.mathmltooltip": "MathML 数式",
+	"image.tooltip": "イメージの挿入",
+	"insertstuff.tooltip": "素材の挿入",
+	"preview.tooltip": "プレビュー",
+	"quicklink.tooltip": "クイックリンクの挿入"
 };

--- a/lang/ja.js
+++ b/lang/ja.js
@@ -1,0 +1,12 @@
+/* eslint quotes: 0 */
+
+export default {
+	"htmleditor.equationeditor.chemistrytooltip": "化学方程式",
+	"htmleditor.equationeditor.graphicaltooltip": "グラフィカル数式",
+	"htmleditor.equationeditor.latextooltip": "LaTeX 数式",
+	"htmleditor.equationeditor.mathmltooltip": "MathML 数式",
+	"htmleditor.image.tooltip": "イメージの挿入",
+	"htmleditor.insertstuff.tooltip": "素材の挿入",
+	"htmleditor.preview.tooltip": "プレビュー",
+	"htmleditor.quicklink.tooltip": "クイックリンクの挿入"
+};

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -1,12 +1,12 @@
 /* eslint quotes: 0 */
 
 export default {
-	"htmleditor.equationeditor.chemistrytooltip": "화학 방정식",
-	"htmleditor.equationeditor.graphicaltooltip": "그래픽 수식",
-	"htmleditor.equationeditor.latextooltip": "LaTeX 수식",
-	"htmleditor.equationeditor.mathmltooltip": "MathML 수식",
-	"htmleditor.image.tooltip": "이미지 삽입",
-	"htmleditor.insertstuff.tooltip": "항목 삽입",
-	"htmleditor.preview.tooltip": "미리 보기",
-	"htmleditor.quicklink.tooltip": "빠른 링크 삽입"
+	"equationeditor.chemistrytooltip": "화학 방정식",
+	"equationeditor.graphicaltooltip": "그래픽 수식",
+	"equationeditor.latextooltip": "LaTeX 수식",
+	"equationeditor.mathmltooltip": "MathML 수식",
+	"image.tooltip": "이미지 삽입",
+	"insertstuff.tooltip": "항목 삽입",
+	"preview.tooltip": "미리 보기",
+	"quicklink.tooltip": "빠른 링크 삽입"
 };

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -1,0 +1,12 @@
+/* eslint quotes: 0 */
+
+export default {
+	"htmleditor.equationeditor.chemistrytooltip": "화학 방정식",
+	"htmleditor.equationeditor.graphicaltooltip": "그래픽 수식",
+	"htmleditor.equationeditor.latextooltip": "LaTeX 수식",
+	"htmleditor.equationeditor.mathmltooltip": "MathML 수식",
+	"htmleditor.image.tooltip": "이미지 삽입",
+	"htmleditor.insertstuff.tooltip": "항목 삽입",
+	"htmleditor.preview.tooltip": "미리 보기",
+	"htmleditor.quicklink.tooltip": "빠른 링크 삽입"
+};

--- a/lang/localizer.js
+++ b/lang/localizer.js
@@ -1,0 +1,74 @@
+import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+
+export const Localizer = superclass => class extends LocalizeMixin(superclass) {
+
+	static async getLocalizeResources(langs) {
+		let translations;
+		for await (const lang of langs) {
+			switch (lang) {
+				case 'ar':
+					translations = await import('./ar.js');
+					break;
+				case 'cy':
+					translations = await import('./cy.js');
+					break;
+				case 'da':
+					translations = await import('./da.js');
+					break;
+				case 'de':
+					translations = await import('./de.js');
+					break;
+				case 'en':
+					translations = await import('./en.js');
+					break;
+				case 'es-es':
+					translations = await import('./es-es.js');
+					break;
+				case 'es':
+					translations = await import('./es.js');
+					break;
+				case 'fr-fr':
+					translations = await import('./fr-fr.js');
+					break;
+				case 'fr':
+					translations = await import('./fr.js');
+					break;
+				case 'ja':
+					translations = await import('./ja.js');
+					break;
+				case 'ko':
+					translations = await import('./ko.js');
+					break;
+				case 'nl':
+					translations = await import('./nl.js');
+					break;
+				case 'pt':
+					translations = await import('./pt.js');
+					break;
+				case 'sv':
+					translations = await import('./sv.js');
+					break;
+				case 'tr':
+					translations = await import('./tr.js');
+					break;
+				case 'zh-tw':
+					translations = await import('./zh-tw.js');
+					break;
+				case 'zh':
+					translations = await import('./zh.js');
+					break;
+			}
+			if (translations && translations.default) {
+				return {
+					language: lang,
+					resources: translations.default
+				};
+			}
+		}
+		translations = await import('./en.js');
+		return {
+			language: 'en',
+			resources: translations.default
+		};
+	}
+};

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -1,12 +1,12 @@
 /* eslint quotes: 0 */
 
 export default {
-	"htmleditor.equationeditor.chemistrytooltip": "Scheikundige vergelijking",
-	"htmleditor.equationeditor.graphicaltooltip": "Grafische vergelijking",
-	"htmleditor.equationeditor.latextooltip": "LaTeX-vergelijking",
-	"htmleditor.equationeditor.mathmltooltip": "MathML-vergelijking",
-	"htmleditor.image.tooltip": "Afbeelding invoegen",
-	"htmleditor.insertstuff.tooltip": "Inhoud invoegen",
-	"htmleditor.preview.tooltip": "Voorbeeldweergave",
-	"htmleditor.quicklink.tooltip": "QuickLink invoegen"
+	"equationeditor.chemistrytooltip": "Scheikundige vergelijking",
+	"equationeditor.graphicaltooltip": "Grafische vergelijking",
+	"equationeditor.latextooltip": "LaTeX-vergelijking",
+	"equationeditor.mathmltooltip": "MathML-vergelijking",
+	"image.tooltip": "Afbeelding invoegen",
+	"insertstuff.tooltip": "Inhoud invoegen",
+	"preview.tooltip": "Voorbeeldweergave",
+	"quicklink.tooltip": "QuickLink invoegen"
 };

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -1,0 +1,12 @@
+/* eslint quotes: 0 */
+
+export default {
+	"htmleditor.equationeditor.chemistrytooltip": "Scheikundige vergelijking",
+	"htmleditor.equationeditor.graphicaltooltip": "Grafische vergelijking",
+	"htmleditor.equationeditor.latextooltip": "LaTeX-vergelijking",
+	"htmleditor.equationeditor.mathmltooltip": "MathML-vergelijking",
+	"htmleditor.image.tooltip": "Afbeelding invoegen",
+	"htmleditor.insertstuff.tooltip": "Inhoud invoegen",
+	"htmleditor.preview.tooltip": "Voorbeeldweergave",
+	"htmleditor.quicklink.tooltip": "QuickLink invoegen"
+};

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -1,0 +1,12 @@
+/* eslint quotes: 0 */
+
+export default {
+	"htmleditor.equationeditor.chemistrytooltip": "Equação química",
+	"htmleditor.equationeditor.graphicaltooltip": "Equação gráfica",
+	"htmleditor.equationeditor.latextooltip": "Equação LaTeX",
+	"htmleditor.equationeditor.mathmltooltip": "Equação MathML",
+	"htmleditor.image.tooltip": "Inserir Imagem",
+	"htmleditor.insertstuff.tooltip": "Inserir Item",
+	"htmleditor.preview.tooltip": "Visualizar",
+	"htmleditor.quicklink.tooltip": "Inserir Link Direto"
+};

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -1,12 +1,12 @@
 /* eslint quotes: 0 */
 
 export default {
-	"htmleditor.equationeditor.chemistrytooltip": "Equação química",
-	"htmleditor.equationeditor.graphicaltooltip": "Equação gráfica",
-	"htmleditor.equationeditor.latextooltip": "Equação LaTeX",
-	"htmleditor.equationeditor.mathmltooltip": "Equação MathML",
-	"htmleditor.image.tooltip": "Inserir Imagem",
-	"htmleditor.insertstuff.tooltip": "Inserir Item",
-	"htmleditor.preview.tooltip": "Visualizar",
-	"htmleditor.quicklink.tooltip": "Inserir Link Direto"
+	"equationeditor.chemistrytooltip": "Equação química",
+	"equationeditor.graphicaltooltip": "Equação gráfica",
+	"equationeditor.latextooltip": "Equação LaTeX",
+	"equationeditor.mathmltooltip": "Equação MathML",
+	"image.tooltip": "Inserir Imagem",
+	"insertstuff.tooltip": "Inserir Item",
+	"preview.tooltip": "Visualizar",
+	"quicklink.tooltip": "Inserir Link Direto"
 };

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -1,12 +1,12 @@
 /* eslint quotes: 0 */
 
 export default {
-	"htmleditor.equationeditor.chemistrytooltip": "Kemiekvation",
-	"htmleditor.equationeditor.graphicaltooltip": "Grafisk ekvation",
-	"htmleditor.equationeditor.latextooltip": "LaTeX-ekvation",
-	"htmleditor.equationeditor.mathmltooltip": "MathML-ekvation",
-	"htmleditor.image.tooltip": "Infoga bild",
-	"htmleditor.insertstuff.tooltip": "Infoga material",
-	"htmleditor.preview.tooltip": "Förhandsgranska",
-	"htmleditor.quicklink.tooltip": "Infoga snabblänk"
+	"equationeditor.chemistrytooltip": "Kemiekvation",
+	"equationeditor.graphicaltooltip": "Grafisk ekvation",
+	"equationeditor.latextooltip": "LaTeX-ekvation",
+	"equationeditor.mathmltooltip": "MathML-ekvation",
+	"image.tooltip": "Infoga bild",
+	"insertstuff.tooltip": "Infoga material",
+	"preview.tooltip": "Förhandsgranska",
+	"quicklink.tooltip": "Infoga snabblänk"
 };

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -1,0 +1,12 @@
+/* eslint quotes: 0 */
+
+export default {
+	"htmleditor.equationeditor.chemistrytooltip": "Kemiekvation",
+	"htmleditor.equationeditor.graphicaltooltip": "Grafisk ekvation",
+	"htmleditor.equationeditor.latextooltip": "LaTeX-ekvation",
+	"htmleditor.equationeditor.mathmltooltip": "MathML-ekvation",
+	"htmleditor.image.tooltip": "Infoga bild",
+	"htmleditor.insertstuff.tooltip": "Infoga material",
+	"htmleditor.preview.tooltip": "Förhandsgranska",
+	"htmleditor.quicklink.tooltip": "Infoga snabblänk"
+};

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -1,0 +1,12 @@
+/* eslint quotes: 0 */
+
+export default {
+	"htmleditor.equationeditor.chemistrytooltip": "Kimya denklemi",
+	"htmleditor.equationeditor.graphicaltooltip": "Grafik denklem",
+	"htmleditor.equationeditor.latextooltip": "LaTeX denklemi",
+	"htmleditor.equationeditor.mathmltooltip": "MathML denklemi",
+	"htmleditor.image.tooltip": "Görüntü Ekle",
+	"htmleditor.insertstuff.tooltip": "Öğe Ekle",
+	"htmleditor.preview.tooltip": "Ön izleme",
+	"htmleditor.quicklink.tooltip": "Hızlı Bağlantı Ekle"
+};

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -1,12 +1,12 @@
 /* eslint quotes: 0 */
 
 export default {
-	"htmleditor.equationeditor.chemistrytooltip": "Kimya denklemi",
-	"htmleditor.equationeditor.graphicaltooltip": "Grafik denklem",
-	"htmleditor.equationeditor.latextooltip": "LaTeX denklemi",
-	"htmleditor.equationeditor.mathmltooltip": "MathML denklemi",
-	"htmleditor.image.tooltip": "Görüntü Ekle",
-	"htmleditor.insertstuff.tooltip": "Öğe Ekle",
-	"htmleditor.preview.tooltip": "Ön izleme",
-	"htmleditor.quicklink.tooltip": "Hızlı Bağlantı Ekle"
+	"equationeditor.chemistrytooltip": "Kimya denklemi",
+	"equationeditor.graphicaltooltip": "Grafik denklem",
+	"equationeditor.latextooltip": "LaTeX denklemi",
+	"equationeditor.mathmltooltip": "MathML denklemi",
+	"image.tooltip": "Görüntü Ekle",
+	"insertstuff.tooltip": "Öğe Ekle",
+	"preview.tooltip": "Ön izleme",
+	"quicklink.tooltip": "Hızlı Bağlantı Ekle"
 };

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -1,0 +1,12 @@
+/* eslint quotes: 0 */
+
+export default {
+	"htmleditor.equationeditor.chemistrytooltip": "化學方程式",
+	"htmleditor.equationeditor.graphicaltooltip": "圖形方程式",
+	"htmleditor.equationeditor.latextooltip": "LaTeX 方程式",
+	"htmleditor.equationeditor.mathmltooltip": "MathML 方程式",
+	"htmleditor.image.tooltip": "插入影像",
+	"htmleditor.insertstuff.tooltip": "插入媒體",
+	"htmleditor.preview.tooltip": "預覽",
+	"htmleditor.quicklink.tooltip": "插入快速連結"
+};

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -1,12 +1,12 @@
 /* eslint quotes: 0 */
 
 export default {
-	"htmleditor.equationeditor.chemistrytooltip": "化學方程式",
-	"htmleditor.equationeditor.graphicaltooltip": "圖形方程式",
-	"htmleditor.equationeditor.latextooltip": "LaTeX 方程式",
-	"htmleditor.equationeditor.mathmltooltip": "MathML 方程式",
-	"htmleditor.image.tooltip": "插入影像",
-	"htmleditor.insertstuff.tooltip": "插入媒體",
-	"htmleditor.preview.tooltip": "預覽",
-	"htmleditor.quicklink.tooltip": "插入快速連結"
+	"equationeditor.chemistrytooltip": "化學方程式",
+	"equationeditor.graphicaltooltip": "圖形方程式",
+	"equationeditor.latextooltip": "LaTeX 方程式",
+	"equationeditor.mathmltooltip": "MathML 方程式",
+	"image.tooltip": "插入影像",
+	"insertstuff.tooltip": "插入媒體",
+	"preview.tooltip": "預覽",
+	"quicklink.tooltip": "插入快速連結"
 };

--- a/lang/zh.js
+++ b/lang/zh.js
@@ -1,12 +1,12 @@
 /* eslint quotes: 0 */
 
 export default {
-	"htmleditor.equationeditor.chemistrytooltip": "化学反应式",
-	"htmleditor.equationeditor.graphicaltooltip": "图形等式",
-	"htmleditor.equationeditor.latextooltip": "LaTeX 等式",
-	"htmleditor.equationeditor.mathmltooltip": "MathML 等式",
-	"htmleditor.image.tooltip": "插入图像",
-	"htmleditor.insertstuff.tooltip": "插入资料",
-	"htmleditor.preview.tooltip": "预览",
-	"htmleditor.quicklink.tooltip": "插入 QuickLink"
+	"equationeditor.chemistrytooltip": "化学反应式",
+	"equationeditor.graphicaltooltip": "图形等式",
+	"equationeditor.latextooltip": "LaTeX 等式",
+	"equationeditor.mathmltooltip": "MathML 等式",
+	"image.tooltip": "插入图像",
+	"insertstuff.tooltip": "插入资料",
+	"preview.tooltip": "预览",
+	"quicklink.tooltip": "插入 QuickLink"
 };

--- a/lang/zh.js
+++ b/lang/zh.js
@@ -1,0 +1,12 @@
+/* eslint quotes: 0 */
+
+export default {
+	"htmleditor.equationeditor.chemistrytooltip": "化学反应式",
+	"htmleditor.equationeditor.graphicaltooltip": "图形等式",
+	"htmleditor.equationeditor.latextooltip": "LaTeX 等式",
+	"htmleditor.equationeditor.mathmltooltip": "MathML 等式",
+	"htmleditor.image.tooltip": "插入图像",
+	"htmleditor.insertstuff.tooltip": "插入资料",
+	"htmleditor.preview.tooltip": "预览",
+	"htmleditor.quicklink.tooltip": "插入 QuickLink"
+};

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "icons.js",
     "/components",
     "/generated",
+    "/lang",
     "/tinymce"
   ],
   "scripts": {


### PR DESCRIPTION
Pretty much does what it says on the tin; enabling support for localizing D2L-specific terms in the editor for custom functionality. This also localizes tooltips for current custom plugins based on existing lang terms in the LMS.