### PR TITLE
US122517 - Add support for overriding TinyMCE iframe title and aria-label attributes

### DIFF
--- a/htmleditor.js
+++ b/htmleditor.js
@@ -103,7 +103,6 @@ class HtmlEditor extends ProviderMixin(Localizer(RtlMixin(LitElement))) {
 			fullPageFontSize: { type: String, attribute: 'full-page-font-size' },
 			height: { type: String },
 			html: { type: String },
-			label: { type: String },
 			noFilter: { type: Boolean, attribute: 'no-filter' },
 			noSpellchecker: { type: Boolean, attribute: 'no-spellchecker' },
 			pasteLocalImages: { type: Boolean, attribute: 'paste-local-images' },
@@ -155,7 +154,6 @@ class HtmlEditor extends ProviderMixin(Localizer(RtlMixin(LitElement))) {
 		this.fullPage = false;
 		this.fullPageFontColor = '#494c4e';
 		this.height = '355px';
-		this.label = '';
 		this.noFilter = false;
 		this.noSpellchecker = false;
 		this.pasteLocalImages = false;
@@ -269,10 +267,7 @@ class HtmlEditor extends ProviderMixin(Localizer(RtlMixin(LitElement))) {
 					}
 
 					const iframe = editor.getContentAreaContainer().firstElementChild;
-					if (iframe) {
-						iframe.title = this.title;
-						if (this.label) iframe.setAttribute('aria-label', this.label);
-					}
+					if (iframe) iframe.title = this.title;
 
 					this._initializationResolve();
 				},

--- a/htmleditor.js
+++ b/htmleditor.js
@@ -103,9 +103,11 @@ class HtmlEditor extends ProviderMixin(Localizer(RtlMixin(LitElement))) {
 			fullPageFontSize: { type: String, attribute: 'full-page-font-size' },
 			height: { type: String },
 			html: { type: String },
+			label: { type: String },
 			noFilter: { type: Boolean, attribute: 'no-filter' },
 			noSpellchecker: { type: Boolean, attribute: 'no-spellchecker' },
 			pasteLocalImages: { type: Boolean, attribute: 'paste-local-images' },
+			title: { type: String },
 			type: { type: String },
 			width: { type: String },
 			_editorId: { type: String }
@@ -153,9 +155,11 @@ class HtmlEditor extends ProviderMixin(Localizer(RtlMixin(LitElement))) {
 		this.fullPage = false;
 		this.fullPageFontColor = '#494c4e';
 		this.height = '355px';
+		this.label = '';
 		this.noFilter = false;
 		this.noSpellchecker = false;
 		this.pasteLocalImages = false;
+		this.title = '';
 		this.type = editorTypes.FULL;
 		this.width = '100%';
 		this._editorId = getUniqueId();
@@ -257,9 +261,17 @@ class HtmlEditor extends ProviderMixin(Localizer(RtlMixin(LitElement))) {
 				height: this.height,
 				images_upload_handler: (blobInfo, success, failure) => uploadImage(this, blobInfo, success, failure),
 				init_instance_callback: editor => {
-					if (editor && editor.plugins && editor.plugins.autosave) {
+					if (!editor) return;
+
+					if (editor.plugins && editor.plugins.autosave) {
 						// removing the autosave plugin prevents saving of content but retains the "ask_before_unload" behaviour
 						delete editor.plugins.autosave;
+					}
+
+					const iframe = editor.getContentAreaContainer().firstElementChild;
+					if (iframe) {
+						iframe.title = this.title;
+						if (this.label) iframe.setAttribute('aria-label', this.label);
 					}
 
 					this._initializationResolve();


### PR DESCRIPTION
TinyMCE puts a title on its iframe by default, but this doesn't particularly serve our purpose. Instead, allow the consumer of the web component to specify the title and (optionally) an aria-label to be used instead.