### PR TITLE
Update HTML Editor equation split button to use new icon by default

### DIFF
--- a/components/equation.js
+++ b/components/equation.js
@@ -58,7 +58,7 @@ tinymce.PluginManager.add('d2l-equation', function(editor) {
 	};
 
 	editor.ui.registry.addSplitButton('d2l-equation', {
-		icon: 'd2l-equation-graphical',
+		icon: 'equation-graphical',
 		tooltip: localize('equationeditor.graphicaltooltip'),
 		onAction: () => {
 			launchEditor(editorTypes.Graphical);


### PR DESCRIPTION
If this was being left as is intentionally, let me know and I'll close this PR out. I'm not sure if there's still more work in the pipeline for the icons.