### PR TITLE
Enable selection and image context toolbars.

### DIFF
--- a/htmleditor.js
+++ b/htmleditor.js
@@ -20,6 +20,7 @@ import 'tinymce/plugins/imagetools/plugin.js';
 import 'tinymce/plugins/link/plugin.js';
 import 'tinymce/plugins/lists/plugin.js';
 import 'tinymce/plugins/preview/plugin.js';
+import 'tinymce/plugins/quickbars/plugin.js';
 import 'tinymce/plugins/table/plugin.js';
 import 'tinymce/plugins/textpattern/plugin.js';
 import 'tinymce/themes/silver/theme.js';
@@ -316,7 +317,8 @@ class HtmlEditor extends ProviderMixin(Localizer(RtlMixin(LitElement))) {
 				},
 				mentions_selector: 'span[data-mentions-id]',
 				object_resizing : true,
-				plugins: `a11ychecker ${this.autoSave ? 'autosave' : ''} advtable autolink charmap advcode directionality emoticons ${this.fullPage ? 'fullpage' : ''} fullscreen hr image ${this.pasteLocalImages ? 'imagetools' : ''} lists link ${(this.mentions && D2L.LP) ? 'mentions' : ''} powerpaste ${D2L.LP ? 'd2l-preview' : 'preview'} table textpattern d2l-equation d2l-image d2l-isf d2l-quicklink d2l-wordcount`,
+				plugins: `a11ychecker ${this.autoSave ? 'autosave' : ''} advtable autolink charmap advcode directionality emoticons ${this.fullPage ? 'fullpage' : ''} fullscreen hr image ${this.pasteLocalImages ? 'imagetools' : ''} lists link ${(this.mentions && D2L.LP) ? 'mentions' : ''} powerpaste ${D2L.LP ? 'd2l-preview' : 'preview'} quickbars table textpattern d2l-equation d2l-image d2l-isf d2l-quicklink d2l-wordcount`,
+				quickbars_insert_toolbar: false,
 				relative_urls: false,
 				resize: true,
 				setup: (editor) => {

--- a/htmleditor.js
+++ b/htmleditor.js
@@ -142,6 +142,15 @@ class HtmlEditor extends ProviderMixin(Localizer(RtlMixin(LitElement))) {
 			.tox .tox-toolbar__group {
 				padding: 0 4px 0 8px; /* snow */
 			}
+			.tox .tox-pop__dialog .tox-toolbar-nav-js {
+				margin-bottom: 0; /* snow */
+				margin-top: 0; /* snow */
+				min-height: auto; /* snow */
+				padding: 0; /* snow */
+			}
+			.tox .tox-pop__dialog .tox-toolbar {
+				background: none; /* snow */
+			}
 			.tox-tinymce-aux,
 			.tox-tinymce.tox-fullscreen {
 				z-index: 1000;


### PR DESCRIPTION
This PR adds the quickbars plugin which includes the selection, insert, and image context toolbars.  However, we explicitly disable the insert context toolbar for the time being since it's sort of annoying.

Selection context toolbar:
![image](https://user-images.githubusercontent.com/9042472/102643321-17966c80-412d-11eb-9321-851b22ba8985.png)

Image context toolbar:
![image](https://user-images.githubusercontent.com/9042472/102643380-2f6df080-412d-11eb-9e5a-dd49d19659f3.png)

This PR also includes fix for the "buggy" (extraneous borders and inconsistent height compared to the other context toolbars) layout of the link context toolbar as shown:
![image](https://user-images.githubusercontent.com/9042472/102643005-95a64380-412c-11eb-82b2-3fa536d55c0f.png)

To look like this instead:
![image](https://user-images.githubusercontent.com/9042472/102643069-afe02180-412c-11eb-9efa-1d9e171f7d02.png)
