### PR TITLE
US122517 - Fire custom event when blur event is fired from the editor; expose editor.isDirty() method on component

### DIFF
--- a/htmleditor.js
+++ b/htmleditor.js
@@ -333,6 +333,16 @@ class HtmlEditor extends ProviderMixin(Localizer(RtlMixin(LitElement))) {
 				setup: (editor) => {
 					addIcons(editor);
 
+					editor.on('blur', () => {
+						if (this.pasteLocalImages) editor.uploadImages();
+
+						this.dispatchEvent(new CustomEvent(
+							'd2l-htmleditor-blur', {
+								bubbles: true
+							}
+						));
+					});
+
 					if (this.pasteLocalImages) editor.on('blur', () => editor.uploadImages());
 
 					const createSplitButton = (name, icon, tooltip, cmd, items) => {
@@ -419,6 +429,11 @@ class HtmlEditor extends ProviderMixin(Localizer(RtlMixin(LitElement))) {
 
 	get initializationComplete() {
 		return this._initializationComplete;
+	}
+
+	get isDirty() {
+		const editor = tinymce.EditorManager.get(this._editorId);
+		return editor.isDirty();
 	}
 
 	_getToolbarConfig() {

--- a/htmleditor.js
+++ b/htmleditor.js
@@ -433,7 +433,7 @@ class HtmlEditor extends ProviderMixin(Localizer(RtlMixin(LitElement))) {
 
 	get isDirty() {
 		const editor = tinymce.EditorManager.get(this._editorId);
-		return isShadowDOMSupported ? editor.isDirty() : false;
+		return isShadowDOMSupported && editor.isDirty();
 	}
 
 	_getToolbarConfig() {

--- a/htmleditor.js
+++ b/htmleditor.js
@@ -433,7 +433,7 @@ class HtmlEditor extends ProviderMixin(Localizer(RtlMixin(LitElement))) {
 
 	get isDirty() {
 		const editor = tinymce.EditorManager.get(this._editorId);
-		return isShadowDOMSupported && editor.isDirty();
+		return (editor && editor.isDirty());
 	}
 
 	_getToolbarConfig() {

--- a/htmleditor.js
+++ b/htmleditor.js
@@ -433,7 +433,7 @@ class HtmlEditor extends ProviderMixin(Localizer(RtlMixin(LitElement))) {
 
 	get isDirty() {
 		const editor = tinymce.EditorManager.get(this._editorId);
-		return editor.isDirty();
+		return isShadowDOMSupported ? editor.isDirty() : false;
 	}
 
 	_getToolbarConfig() {


### PR DESCRIPTION
This makes a couple changes to the component that are likely necessary to align with the old LMS editor's JS APIs. There are two main changes here:
1. Fire a custom event that bubbles up to consumers when the editor itself fires a blur event. This is necessary to handle some change tracking we do in some of our legacy UIs (specifically, on editor blur is when we check whether changes have occurred and update the UI accordingly).
2. Expose TinyMCE's `isDirty()` editor API to consumers of the component. This is the method some of our legacy UI code uses to determine whether an editor has changes or not (different from the change tracking mentioned above).