### PR TITLE
When the editor is fullscreened, add a white background to the editor component to override TinyMCE's transparent defaults

### DIFF
--- a/htmleditor.js
+++ b/htmleditor.js
@@ -153,7 +153,7 @@ class HtmlEditor extends ProviderMixin(Localizer(RtlMixin(LitElement))) {
 			}
 			.tox-tinymce-aux,
 			.tox-tinymce.tox-fullscreen {
-				background-color: #fff;
+				background-color: #ffffff;
 				z-index: 1000;
 			}
 			:host([type="inline"]) .tox-tinymce .tox-toolbar-overlord > div:nth-child(2) {

--- a/htmleditor.js
+++ b/htmleditor.js
@@ -153,6 +153,7 @@ class HtmlEditor extends ProviderMixin(Localizer(RtlMixin(LitElement))) {
 			}
 			.tox-tinymce-aux,
 			.tox-tinymce.tox-fullscreen {
+				background-color: #fff;
 				z-index: 1000;
 			}
 			:host([type="inline"]) .tox-tinymce .tox-toolbar-overlord > div:nth-child(2) {


### PR DESCRIPTION
By default, TinyMCE's Snow skin applies transparent background to all of the editor components (e.g. the menu, toolbar, text input, etc.), which also applies when the editor is used in fullscreen mode. We'll need to file a bug report with them over this, but for now, we can just slap a white background on the editor component when it goes fullscreen to work around this.