### PR TITLE
Parse units from provided height property and ensure we're setting the minimum height accordingly

### DIFF
--- a/htmleditor.js
+++ b/htmleditor.js
@@ -446,11 +446,13 @@ class HtmlEditor extends ProviderMixin(Localizer(RtlMixin(LitElement))) {
 		const heightValue = heightParts[0];
 		const heightUnits = heightParts[1];
 
+		const fontSizeValue = rootFontSize.replace('px','');
+
 		switch (heightUnits) {
 			case 'px':
 				return heightValue < defaultMinHeight ? heightValue : defaultMinHeight;
 			case 'rem':
-				return (heightValue * 20) < defaultMinHeight ? (heightValue * 20) : defaultMinHeight;
+				return (heightValue * fontSizeValue) < defaultMinHeight ? (heightValue * fontSizeValue) : defaultMinHeight;
 			default:
 				return defaultMinHeight;
 		}

--- a/htmleditor.js
+++ b/htmleditor.js
@@ -446,7 +446,7 @@ class HtmlEditor extends ProviderMixin(Localizer(RtlMixin(LitElement))) {
 		const heightValue = heightParts[0];
 		const heightUnits = heightParts[1];
 
-		const fontSizeValue = rootFontSize.replace('px','');
+		const fontSizeValue = rootFontSize.replace('px', '');
 
 		switch (heightUnits) {
 			case 'px':

--- a/htmleditor.js
+++ b/htmleditor.js
@@ -311,7 +311,7 @@ class HtmlEditor extends ProviderMixin(Localizer(RtlMixin(LitElement))) {
 				link_context_toolbar: true,
 				link_default_protocol: 'https',
 				menubar: false,
-				min_height: this.height < 300 ? this.height : 300,
+				min_height: this._getMinHeight(),
 				mentions_fetch: (query, success) => {
 					setTimeout(() => D2L.LP.Web.UI.Rpc.Connect(
 						D2L.LP.Web.UI.Rpc.Verbs.GET,
@@ -435,6 +435,25 @@ class HtmlEditor extends ProviderMixin(Localizer(RtlMixin(LitElement))) {
 	get isDirty() {
 		const editor = tinymce.EditorManager.get(this._editorId);
 		return (editor && editor.isDirty());
+	}
+
+	_getMinHeight() {
+		const defaultMinHeight = 300;
+		const heightParts = this.height.split(/(?<=\d)(?=\D)/);
+
+		if (heightParts.length !== 2) return defaultMinHeight;
+
+		const heightValue = heightParts[0];
+		const heightUnits = heightParts[1];
+
+		switch (heightUnits) {
+			case 'px':
+				return heightValue < defaultMinHeight ? heightValue : defaultMinHeight;
+			case 'rem':
+				return (heightValue * 20) < defaultMinHeight ? (heightValue * 20) : defaultMinHeight;
+			default:
+				return defaultMinHeight;
+		}
 	}
 
 	_getToolbarConfig() {


### PR DESCRIPTION
When we compare the default minimum height of `300px` against the height of the editor to determine which value to use, we should make sure to compare appropriately against whatever units the consumer provides. We can't really convert `%` well because we don't have access to the height of the bounding container, but we can ensure we're converting `px` and `rem` properly by parsing out the units and either using the values directly (in the case of `px`) or converting to `px` and then comparing (in the case of `rem`).