### PR TITLE
Switch to using label on web component instead of only updating the iframe title

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Types of editors (toolbar features):
 
 **Properties:**
 
-| Property | &nbsp; &nbsp; &nbsp; Type &nbsp; &nbsp; &nbsp; | Description |
+| Property | Type | Description |
 |--|--|--|
 | `attached-images-only` | Boolean | Whether or not to restrict image uploads to attachments and prevent saving to course/shared files. |
 | `auto-save` | Boolean | Whether or not to prompt the user when navigating away from the page while the editor has unsaved content. |
@@ -71,7 +71,7 @@ Types of editors (toolbar features):
 
 **Events:**
 
-| &nbsp; &nbsp; &nbsp; Event &nbsp; &nbsp; &nbsp; | Properties | Description |
+| Event | Properties | Description |
 |--|--|--|
 | `d2l-htmleditor-blur` | None | Dispatched when TinyMCE fires a blur event on the editor. |
 | `d2l-htmleditor-image-upload-complete` | None | Dispatched when images finish uploading to the editor. If multiple images are being uploaded, the event will only be dispatched once all images are uploaded. |

--- a/README.md
+++ b/README.md
@@ -38,29 +38,30 @@ Types of editors (toolbar features):
 
 **Properties:**
 
-| Property | Type | Description |
+| Property | &nbsp; &nbsp; &nbsp; Type &nbsp; &nbsp; &nbsp; | Description |
 |--|--|--|
-| `attached-images-only` | Boolean | Whether or not to restrict image uploads to attachments and prevent saving to course/shared files. Defaults to `false`. |
-| `auto-save` | Boolean | Whether or not to prompt the user when navigating away from the page while the editor has unsaved content. Defaults to `false`. |
-| `disabled` | Boolean | Whether the content is read-only. Defaults to `false`. |
+| `attached-images-only` | Boolean | Whether or not to restrict image uploads to attachments and prevent saving to course/shared files. |
+| `auto-save` | Boolean | Whether or not to prompt the user when navigating away from the page while the editor has unsaved content. |
+| `disabled` | Boolean | Whether the content is read-only. |
 | `files` | Array | Read-only. An array of FileInfo objects for files added. |
-| `file-upload-for-all-users` | Boolean | Whether or not to enable file uploads to course or shared files. Defaults to `false`. |
-| `full-page` | Boolean | Whether an HTML document or fragment is being authored. Defaults to `false`. |
-| `full-page-font-color` | String | The `body` font color. Defaults to ferrite. Only applies when `full-page` is `true`. |
-| `full-page-font-family` | String | The `body` font. Defaults to the browser default. Only applies when `full-page` is `true`. |
-| `full-page-font-size` | String | The `body` font size. Defaults to browser default. Only applies when `full-page` is `true`. |
-| `height` | String | Initial height of the editor in `px`, `rem`, or `%`. Defaults to 355px. |
-| `html` | String | The HTML being authored. Defaults to empty string. |
+| `file-upload-for-all-users` | Boolean | Whether or not to enable file uploads to course or shared files. |
+| `full-page` | Boolean | Whether an HTML document or fragment is being authored. |
+| `full-page-font-color` | String, default: `'#494c4e'` (ferrite) | The `body` font color. Only applies when `full-page` is `true`. |
+| `full-page-font-family` | String, default: Browser default | The `body` font. Only applies when `full-page` is `true`. |
+| `full-page-font-size` | String, default: Browser default | The `body` font size. Only applies when `full-page` is `true`. |
+| `height` | String, default: `'355px'` | Initial height of the editor in `px`, `rem`, or `%`. |
+| `html` | String, default: `''` | The HTML being authored. |
 | `initializationComplete` | Promise | Read-only. Fulfilled when the editor has been fully initialized; pending otherwise. |
 | `isDirty` | Boolean | Read-only. Whether or not the editor is [dirty](https://www.tiny.cloud/docs/api/tinymce/tinymce.editor/#isdirty). |
-| `mentions` | Boolean | Whether or not to enable [@mentions](https://www.tiny.cloud/docs/enterprise/mentions/). Defaults to `false`. |
-| `no-filter` | Boolean | Whether or not to disable filtering for the content. Defaults to `false`. |
-| `no-spellchecker` | Boolean | Whether or not to disable spell checking. Defaults to `false`. |
-| `paste-local-images` | Boolean | Whether or not to enable local image pasting and drag-and-drop. Defaults to `false`. |
-| `title` | String | Accessible text that describes the editor content. Defaults to empty string. |
-| `type` | String | Whether to render the editor in `full`, `inline`, or `inline-limited` mode. Defaults to `full`. |
-| `width` | String | Initial width of the editor. Defaults to 100% of its bounding container. |
-| `word-count-in-footer` | Boolean | Whether or not to display the current word/character counts in the editor footer. Defaults to `false`.
+| `label` | String, required | Label for the editor. |
+| `label-hidden` | Boolean | Hides the label visually. |
+| `mentions` | Boolean | Whether or not to enable [@mentions](https://www.tiny.cloud/docs/enterprise/mentions/). |
+| `no-filter` | Boolean | Whether or not to disable filtering for the content. |
+| `no-spellchecker` | Boolean | Whether or not to disable spell checking. |
+| `paste-local-images` | Boolean | Whether or not to enable local image pasting and drag-and-drop. |
+| `type` | String, default: `'full'` | Whether to render the editor in `full`, `inline`, or `inline-limited` mode. |
+| `width` | String, default: 100% of bounding container | Initial width of the editor. |
+| `word-count-in-footer` | Boolean | Whether or not to display the current word/character counts in the editor footer.
 
 **Methods:**
 
@@ -70,7 +71,7 @@ Types of editors (toolbar features):
 
 **Events:**
 
-| Event | Properties | Description |
+| &nbsp; &nbsp; &nbsp; Event &nbsp; &nbsp; &nbsp; | Properties | Description |
 |--|--|--|
 | `d2l-htmleditor-blur` | None | Dispatched when TinyMCE fires a blur event on the editor. |
 | `d2l-htmleditor-image-upload-complete` | None | Dispatched when images finish uploading to the editor. If multiple images are being uploaded, the event will only be dispatched once all images are uploaded. |

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Types of editors (toolbar features):
 
 **Properties:**
 
-| Property | Type | Description |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Property&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Type&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Description |
 |--|--|--|
 | `attached-images-only` | Boolean | Whether or not to restrict image uploads to attachments and prevent saving to course/shared files. |
 | `auto-save` | Boolean | Whether or not to prompt the user when navigating away from the page while the editor has unsaved content. |
@@ -71,7 +71,7 @@ Types of editors (toolbar features):
 
 **Events:**
 
-| Event | Properties | Description |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Event&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Properties | Description |
 |--|--|--|
 | `d2l-htmleditor-blur` | None | Dispatched when TinyMCE fires a blur event on the editor. |
 | `d2l-htmleditor-image-upload-complete` | None | Dispatched when images finish uploading to the editor. If multiple images are being uploaded, the event will only be dispatched once all images are uploaded. |

--- a/htmleditor.js
+++ b/htmleditor.js
@@ -29,6 +29,7 @@ import { css, html, LitElement, unsafeCSS } from 'lit-element/lit-element.js';
 import { addIcons } from './generated/icons.js';
 import { classMap } from 'lit-html/directives/class-map.js';
 import { getUniqueId } from '@brightspace-ui/core/helpers/uniqueId.js';
+import { inputLabelStyles } from '@brightspace-ui/core/components/inputs/input-label-styles.js';
 import { isfStyles } from './components/isf.js';
 import { Localizer } from './lang/localizer.js';
 import { ProviderMixin } from '@brightspace-ui/core/mixins/provider-mixin.js';
@@ -116,11 +117,12 @@ class HtmlEditor extends SkeletonMixin(ProviderMixin(Localizer(RtlMixin(LitEleme
 			fullPageFontSize: { type: String, attribute: 'full-page-font-size' },
 			height: { type: String },
 			html: { type: String },
+			label: { type: String },
+			labelHidden: { type: Boolean, attribute: 'label-hidden' },
 			mentions: { type: Boolean },
 			noFilter: { type: Boolean, attribute: 'no-filter' },
 			noSpellchecker: { type: Boolean, attribute: 'no-spellchecker' },
 			pasteLocalImages: { type: Boolean, attribute: 'paste-local-images' },
-			title: { type: String },
 			type: { type: String },
 			width: { type: String },
 			wordCountInFooter: { type: Boolean, attribute: 'word-count-in-footer' },
@@ -129,7 +131,7 @@ class HtmlEditor extends SkeletonMixin(ProviderMixin(Localizer(RtlMixin(LitEleme
 	}
 
 	static get styles() {
-		return [ super.styles, css`
+		return [ super.styles, inputLabelStyles, css`
 			:host {
 				display: block;
 			}
@@ -191,11 +193,12 @@ class HtmlEditor extends SkeletonMixin(ProviderMixin(Localizer(RtlMixin(LitEleme
 		this.fullPage = false;
 		this.fullPageFontColor = '#494c4e';
 		this.height = '355px';
+		this.label = '';
+		this.labelHidden = false;
 		this.mentions = false;
 		this.noFilter = false;
 		this.noSpellchecker = false;
 		this.pasteLocalImages = false;
-		this.title = '';
 		this.type = editorTypes.FULL;
 		this.width = '100%';
 		this.wordCountInFooter = false;
@@ -311,7 +314,7 @@ class HtmlEditor extends SkeletonMixin(ProviderMixin(Localizer(RtlMixin(LitEleme
 					}
 
 					const iframe = editor.getContentAreaContainer().firstElementChild;
-					if (iframe) iframe.title = this.title;
+					if (iframe) iframe.title = this.label;
 
 					this._initializationResolve();
 				},
@@ -424,11 +427,8 @@ class HtmlEditor extends SkeletonMixin(ProviderMixin(Localizer(RtlMixin(LitEleme
 	render() {
 
 		if (this.disabled) {
-			const htmlBlockClasses = {
-				'd2l-skeletize': this.skeleton
-			};
 			return html`
-				<d2l-html-block class="${classMap(htmlBlockClasses)}">
+				<d2l-html-block class="d2l-skeletize">
 					<template>${unsafeHTML(this._html)}</template>
 				</d2l-html-block>`;
 		}
@@ -436,16 +436,13 @@ class HtmlEditor extends SkeletonMixin(ProviderMixin(Localizer(RtlMixin(LitEleme
 		const textAreaClasses = {
 			'd2l-htmleditor-no-tinymce': !isShadowDOMSupported
 		};
-		const containerClasses = {
-			'd2l-htmleditor-container': true,
-			'd2l-skeletize': this.skeleton
-		};
 
 		//if (this.type === editorTypes.INLINE || this.type === editorTypes.INLINE_LIMITED) {
 		//	return html`<div id="${this._editorId}" .innerHTML="${this._html}"></div>`;
 		//} else {
 		return html`
-			<div class="${classMap(containerClasses)}">
+		${this.label && !this.labelHidden ? html`<span class="d2l-input-label d2l-skeletize" aria-hidden="true">${this.label}</span>` : ''}
+			<div class="d2l-htmleditor-container d2l-skeletize">
 				<textarea id="${this._editorId}" class="${classMap(textAreaClasses)}" aria-hidden="true" tabindex="-1">${this._html}</textarea>
 			</div>
 		${!isShadowDOMSupported ? html`<d2l-alert>Web Components are not supported in this browser. Upgrade or switch to a newer browser to use the shiny new HtmlEditor.</d2l-alert>` : ''}`;


### PR DESCRIPTION
These changes should help align the control with our other input controls. The way we're applying the label is a bit odd, because iframes aren't labelable. Done this way, screenreaders will ignore the span element written with the label in it, but will still read out the label from the iframe's title. The Interwebs were uncertain when it comes to whether it would be acceptable and/or better to use an actual `label` element here instead of a span, but from what I can see, the broad idea is "no, don't apply labels to unlabelable elements". I don't personally feel strongly about this though, so I'm open to changing that.