### PR TITLE
increase precedence of style override

### DIFF
--- a/htmleditor.js
+++ b/htmleditor.js
@@ -163,7 +163,7 @@ class HtmlEditor extends SkeletonMixin(ProviderMixin(Localizer(RtlMixin(LitEleme
 				background: none; /* snow */
 			}
 			.tox-tinymce-aux,
-			.tox-tinymce.tox-fullscreen {
+			.tox.tox-tinymce.tox-fullscreen {
 				background-color: #ffffff;
 				z-index: 1000;
 			}


### PR DESCRIPTION
Fixes https://trello.com/c/sYrL3tsh/303-new-html-editor-cannot-use-emoji-picker-math-editor-etc-in-the-expanded-html-editor, which states that in expanded view, the emoji, special character, and equation picker dialogs show up behind the editor. The css that is supposed to be overridden in the the tinymce skin styles, [e.g. this one](https://github.com/BrightspaceUI/htmleditor/blob/master/tinymce/skins/ui/oxide/skin.css#L1933), was not specific enough to take precedence over the skin.css one.