### PR TITLE
fix: find height parts without lookbehind assertions

### DIFF
--- a/htmleditor.js
+++ b/htmleditor.js
@@ -468,9 +468,9 @@ class HtmlEditor extends SkeletonMixin(ProviderMixin(Localizer(RtlMixin(LitEleme
 		const defaultMinHeight = 300;
 		const splitPosition = this.height.search(/\D/);
 
-		if(splitPosition === -1) return defaultMinHeight;
+		if (splitPosition === -1) return defaultMinHeight;
 
-		const heightValue = this.height.slice(0, pos);
+		const heightValue = this.height.slice(0, splitPosition);
 		const heightUnits = this.height.replace(heightValue, '');
 
 		const fontSizeValue = rootFontSize.replace('px', '');

--- a/htmleditor.js
+++ b/htmleditor.js
@@ -466,12 +466,12 @@ class HtmlEditor extends SkeletonMixin(ProviderMixin(Localizer(RtlMixin(LitEleme
 
 	_getMinHeight() {
 		const defaultMinHeight = 300;
-		const heightParts = this.height.split(/(?<=\d)(?=\D)/);
+		const splitPosition = this.height.search(/\D/);
 
-		if (heightParts.length !== 2) return defaultMinHeight;
+		if(splitPosition === -1) return defaultMinHeight;
 
-		const heightValue = heightParts[0];
-		const heightUnits = heightParts[1];
+		const heightValue = this.height.slice(0, pos);
+		const heightUnits = this.height.replace(heightValue, '');
 
 		const fontSizeValue = rootFontSize.replace('px', '');
 


### PR DESCRIPTION
The new editor does not display at all in mac/safari, with console error "Invalid regular expression: invalid group specifier name". Looks like it's because of [the Lookbehind assertion used here](https://github.com/BrightspaceUI/htmleditor/blob/master/htmleditor.js#L469) which are not supported by safari. This fix gets the height value and units without using these assertions.

