### PR TITLE
lms adapter

### DIFF
--- a/components/lms-adapter.js
+++ b/components/lms-adapter.js
@@ -1,0 +1,76 @@
+
+let contextPromise;
+
+export function getContext() {
+	if (contextPromise) return contextPromise;
+
+	contextPromise = new Promise(async resolve => { // eslint-disable-line no-async-promise-executor
+		if (window.ifrauclient) {
+			const ifrauClient = await window.ifrauclient().connect();
+			const editorService = await ifrauClient.getService('htmleditor', '0.1');
+			resolve(JSON.parse(await editorService.getContext()));
+		} else {
+			resolve(JSON.parse(document.documentElement.getAttribute('data-he-context')));
+		}
+	});
+
+	return contextPromise;
+}
+
+export function hasLmsContext() {
+	return D2L.LP || window.ifrauclient;
+}
+
+let dialogService;
+
+export async function openLegacyDialog(location, settings) {
+	if (window.ifrauclient) {
+
+		if (!dialogService) {
+			const ifrauClient = await window.ifrauclient().connect();
+			dialogService = await ifrauClient.getService('dialog', '0.1');
+		}
+
+		try {
+			const result = await dialogService.openLegacy(
+				location,
+				{
+					PreferredSize: {
+						PreferredHeight: settings.height,
+						PreferredWidth: settings.width
+					}
+				},
+				settings.buttons,
+				settings.srcCallback,
+				settings.responseDataKey
+			);
+			return result;
+		} catch (e) {
+			// aborting the dialog rejects the promise so we swallow exception here
+			return '';
+		}
+
+	} else {
+
+		const result = await (new Promise(resolve => {
+			const dialogResult = D2L.LP.Web.UI.Legacy.MasterPages.Dialog.Open(
+				settings.opener,
+				new D2L.LP.Web.Http.UrlLocation(location),
+				settings.srcCallback,
+				null,
+				settings.responseDataKey,
+				settings.width,
+				settings.height,
+				null,
+				settings.buttons,
+				false,
+				null
+			);
+
+			dialogResult.AddReleaseListener(resolve);
+			dialogResult.AddListener(stuff => resolve(stuff));
+		}));
+
+		return result;
+	}
+}

--- a/htmleditor.js
+++ b/htmleditor.js
@@ -28,6 +28,7 @@ import 'tinymce/themes/silver/theme.js';
 import { css, html, LitElement, unsafeCSS } from 'lit-element/lit-element.js';
 import { addIcons } from './generated/icons.js';
 import { classMap } from 'lit-html/directives/class-map.js';
+import { getContext } from './components/lms-adapter.js';
 import { getUniqueId } from '@brightspace-ui/core/helpers/uniqueId.js';
 import { inputLabelStyles } from '@brightspace-ui/core/components/inputs/input-label-styles.js';
 import { isfStyles } from './components/isf.js';
@@ -57,21 +58,6 @@ const editorTypes = {
 };
 
 const isShadowDOMSupported = !(window.ShadyDOM && window.ShadyDOM.inUse);
-
-let contextPromise;
-const getContext = () => {
-	if (contextPromise) return contextPromise;
-	contextPromise = new Promise(async resolve => { // eslint-disable-line no-async-promise-executor
-		if (window.ifrauclient) {
-			const ifrauClient = await window.ifrauclient().connect();
-			const ifrauEditorService = await ifrauClient.getService('htmleditor', '0.1');
-			resolve(JSON.parse(await ifrauEditorService.getContext()));
-		} else {
-			resolve(JSON.parse(document.documentElement.getAttribute('data-he-context')));
-		}
-	});
-	return contextPromise;
-};
 
 const rootFontSize = window.getComputedStyle(document.documentElement, null).getPropertyValue('font-size');
 


### PR DESCRIPTION
This PR introduces an adapter for integration in the LMS either directly or via `ifrau`. It also moves the context resolution from `htmleditor.js`, and updates the ISF plugin to use it for launching the legacy dialog.