### PR TITLE
DE42313 - Don't query outdent menu button state on select (it always returns true if the content can be outdented)

### DIFF
--- a/htmleditor.js
+++ b/htmleditor.js
@@ -394,7 +394,7 @@ class HtmlEditor extends SkeletonMixin(ProviderMixin(Localizer(RtlMixin(LitEleme
 							tooltip: tooltip,
 							onAction: () => editor.execCommand(cmd),
 							onItemAction: (api, value) => editor.execCommand(value),
-							select: value => editor.queryCommandState(value),
+							select: value => value !== 'outdent' && editor.queryCommandState(value),
 							fetch: callback => callback(items)
 						});
 					};


### PR DESCRIPTION
The outdent command actually has a valid state response to `queryCommandState`... Specifically, it returns true iff the current selected content (or the location of the caret) can be outdented. This leads to the outdent option always showing as active in our split button menu, provided any indentation has been applied (either through explicit indentation or one of the list options).