### PR TITLE
Restrict TinyMCE's context menu to just images and tables

### DIFF
--- a/htmleditor.js
+++ b/htmleditor.js
@@ -321,6 +321,7 @@ class HtmlEditor extends SkeletonMixin(ProviderMixin(Localizer(RtlMixin(LitEleme
 				convert_urls: false,
 				content_css: `${baseImportPath}/tinymce/skins/content/default/content.css`,
 				content_style: this.fullPage ? isfStyles : `${contentFragmentStyles} ${isfStyles}`,
+				contextmenu: 'image imagetools table',
 				directionality: this.dir ? this.dir : 'ltr',
 				elementpath: false,
 				extended_valid_elements: 'span[*]',


### PR DESCRIPTION
The `contextmenu` config is a bit interesting. According to [TinyMCE's docs](https://www.tiny.cloud/docs/ui-components/contextmenu/#contextmenu), it defines which context menu options are available to the right click menu, disabling it entirely if it's set to `false`. We can use this to get the behaviour we want by limiting the config to `image imagetools table` because those three context menu items already only conditionally appear when right clicking on an image or in a table respectively. Hence the context menu only opens if we're in one of those contexts, defaulting to the native browser menu otherwise.