### PR TITLE
explicitly add required styles to host

### DIFF
--- a/htmleditor.js
+++ b/htmleditor.js
@@ -140,7 +140,7 @@ class HtmlEditor extends SkeletonMixin(ProviderMixin(Localizer(RtlMixin(LitEleme
 				position: fixed;
 			}
 			:host(.tox-shadowhost.tox-fullscreen) {
-				z-index: 1200;
+				z-index: 1000;
 			}
 			.d2l-htmleditor-container {
 				border: 1px solid var(--d2l-color-mica); /* snow */

--- a/htmleditor.js
+++ b/htmleditor.js
@@ -135,6 +135,12 @@ class HtmlEditor extends SkeletonMixin(ProviderMixin(Localizer(RtlMixin(LitEleme
 			:host([hidden]) {
 				display: none;
 			}
+			:host(.tox-fullscreen) {
+				position: fixed;
+			}
+			:host(.tox-shadowhost.tox-fullscreen) {
+				z-index: 1200;
+			}
 			.d2l-htmleditor-container {
 				border: 1px solid var(--d2l-color-mica); /* snow */
 				border-radius: 6px;

--- a/htmleditor.js
+++ b/htmleditor.js
@@ -135,6 +135,7 @@ class HtmlEditor extends SkeletonMixin(ProviderMixin(Localizer(RtlMixin(LitEleme
 			:host([hidden]) {
 				display: none;
 			}
+			/* stylelint-disable selector-class-pattern */
 			:host(.tox-fullscreen) {
 				position: fixed;
 			}
@@ -152,7 +153,6 @@ class HtmlEditor extends SkeletonMixin(ProviderMixin(Localizer(RtlMixin(LitEleme
 			:host([skeleton]) .d2l-skeletize::before {
 				z-index: 2;
 			}
-			/* stylelint-disable selector-class-pattern */
 			.tox .tox-toolbar__group {
 				padding: 0 4px 0 8px; /* snow */
 			}


### PR DESCRIPTION
The emoji and special char picker is cut off on safari when viewed in fullscreen mode:

![mac3](https://user-images.githubusercontent.com/1471557/107467360-b3839980-6b1a-11eb-9469-6d02e621489b.png)

The reason is because [the skin styles](https://github.com/BrightspaceUI/htmleditor/blob/master/tinymce/skins/ui/snow/skin.shadowdom.css) are not being applied to the htmleditor component when displayed within a FACE page. An ideal fix would allow these styles to be applied, but I have not been able to figure out how to do that, so am explicitly adding the styles that I know are required to fix this bug.