### PR TITLE
make sure picker dialog is always on top in Safari

### DIFF
--- a/htmleditor.js
+++ b/htmleditor.js
@@ -171,7 +171,7 @@ class HtmlEditor extends SkeletonMixin(ProviderMixin(Localizer(RtlMixin(LitEleme
 				z-index: 1000;
 			}
 			.tox.tox-silver-sink.tox-tinymce-aux {
-				position: fixed!important; /* Safari fix */
+				position: fixed !important; /* Safari fix */
 			}
 			:host([type="inline"]) .tox-tinymce .tox-toolbar-overlord > div:nth-child(2) {
 				display: none;

--- a/htmleditor.js
+++ b/htmleditor.js
@@ -170,6 +170,9 @@ class HtmlEditor extends SkeletonMixin(ProviderMixin(Localizer(RtlMixin(LitEleme
 				background-color: #ffffff;
 				z-index: 1000;
 			}
+			.tox.tox-silver-sink.tox-tinymce-aux {
+				position: fixed!important; /* Safari fix */
+			}
 			:host([type="inline"]) .tox-tinymce .tox-toolbar-overlord > div:nth-child(2) {
 				display: none;
 			}


### PR DESCRIPTION
The latest issue in Safari looks like this:

![Safari_picker_cutoff](https://user-images.githubusercontent.com/1471557/107717571-c9af6800-6c88-11eb-9e67-a57f391ee0da.png)

It is when the editor is NOT in fullscreen mode. TinyMCE sets these picker positions as element styles, so the only way to overwrite that is to use `!important` as far as I can tell. Though maybe there is a better way if one digs deeper into how TinyMCE decides what to set it to.