### PR TITLE
fix: fix vertical menu items

### DIFF
--- a/htmleditor.js
+++ b/htmleditor.js
@@ -172,6 +172,7 @@ class HtmlEditor extends SkeletonMixin(ProviderMixin(Localizer(RtlMixin(LitEleme
 			}
 			.tox.tox-silver-sink.tox-tinymce-aux {
 				position: fixed !important; /* Safari fix */
+				width: 100%;
 			}
 			:host([type="inline"]) .tox-tinymce .tox-toolbar-overlord > div:nth-child(2) {
 				display: none;


### PR DESCRIPTION
I found a side-effect to the previous `position: fixed !important; /* Safari fix */`:

<img width="306" alt="headingsVertical" src="https://user-images.githubusercontent.com/1471557/107811993-e64cae00-6d23-11eb-8e61-e4e613107876.png">

This happens in all the drop-down pickers. Setting the width to 100% fixes it. 