### PR TITLE
DE42524 - TinyMCE fullscreen shouldn't take precedence over our dialogs

### DIFF
--- a/htmleditor.js
+++ b/htmleditor.js
@@ -140,7 +140,7 @@ class HtmlEditor extends SkeletonMixin(ProviderMixin(Localizer(RtlMixin(LitEleme
 				position: fixed;
 			}
 			:host(.tox-shadowhost.tox-fullscreen) {
-				z-index: 1000;
+				z-index: 1000 !important;
 			}
 			.d2l-htmleditor-no-tinymce {
 				display: none;
@@ -151,7 +151,7 @@ class HtmlEditor extends SkeletonMixin(ProviderMixin(Localizer(RtlMixin(LitEleme
 			.tox-tinymce-aux,
 			.tox.tox-tinymce.tox-fullscreen {
 				background-color: #ffffff;
-				z-index: 1000;
+				z-index: 1000 !important;
 			}
 			.tox.tox-silver-sink.tox-tinymce-aux {
 				position: fixed !important; /* Safari fix */


### PR DESCRIPTION
TinyMCE's fullscreen CSS applies a z-index of 1200 to the host element, as well as the document body and top-level HTML element. Our legacy dialogs have a z-index of 1002 applied (with z-index 1001 for the shim), which means our dialogs end up rendering behind the editor.

I'm not 100% sure why TinyMCE's CSS was taking precedence over our own stylesheet here... Possibly because we're not actually re-rendering the component on fullscreen so their CSS is being applied last? I dunno. I'm starting to think we're going to want to run our own fullscreen because this is getting kind of nutty, so I'm also not feeling as bad about throwing in "hacky" solutions like `!important`.