### PR TITLE
Inject the fonts.css file into fullpage document if lato is being used.

### DIFF
--- a/components/equation.js
+++ b/components/equation.js
@@ -1,5 +1,5 @@
 /* eslint no-useless-escape: 0 */
-
+import 'tinymce/tinymce.js';
 import { css, LitElement } from 'lit-element/lit-element.js';
 import { hasLmsContext, openDialogWithParam } from './lms-adapter.js';
 import { getComposedActiveElement } from '@brightspace-ui/core/helpers/focus.js';

--- a/components/fullpage.js
+++ b/components/fullpage.js
@@ -1,21 +1,23 @@
 import 'tinymce/tinymce.js';
 
+const latoRegEx = /font-family: lato/i;
+
 tinymce.PluginManager.add('d2l-fullpage', function(editor) {
 
-	if (!editor.settings.fullpage_default_font_family.toLowerCase().includes('lato')) return;
-
+	// specifically pull in 0.5.0 containing Lato font
 	const fontsUrl = 'https://s.brightspace.com/lib/fonts/0.5.0/fonts.css';
 
-	editor.on('SetContent', () => {
+	editor.on('GetContent', (e) => {
 
-		const editorDocument = new DOMParser().parseFromString(editor.getContent(), 'text/html');
+		if (!latoRegEx.test(e.content)) return;
 
+		const editorDocument = new DOMParser().parseFromString(e.content, 'text/html');
 		if (!editorDocument.head.querySelector(`link[href="${fontsUrl}"]`)) {
 			const elem = editorDocument.createElement('link');
 			elem.rel = 'stylesheet';
 			elem.href = fontsUrl;
 			editorDocument.head.appendChild(elem);
-			editor.setContent(editorDocument.documentElement.outerHTML);
+			e.content = editorDocument.documentElement.outerHTML;
 		}
 
 	});

--- a/components/fullpage.js
+++ b/components/fullpage.js
@@ -1,0 +1,23 @@
+import 'tinymce/tinymce.js';
+
+tinymce.PluginManager.add('d2l-fullpage', function(editor) {
+
+	if (!editor.settings.fullpage_default_font_family.toLowerCase().includes('lato')) return;
+
+	const fontsUrl = 'https://s.brightspace.com/lib/fonts/0.5.0/fonts.css';
+
+	editor.on('SetContent', () => {
+
+		const editorDocument = new DOMParser().parseFromString(editor.getContent(), 'text/html');
+
+		if (!editorDocument.head.querySelector(`link[href="${fontsUrl}"]`)) {
+			const elem = editorDocument.createElement('link');
+			elem.rel = 'stylesheet';
+			elem.href = fontsUrl;
+			editorDocument.head.appendChild(elem);
+			editor.setContent(editorDocument.documentElement.outerHTML);
+		}
+
+	});
+
+});

--- a/components/fullpage.js
+++ b/components/fullpage.js
@@ -4,7 +4,10 @@ const latoRegEx = /font-family: lato/i;
 
 tinymce.PluginManager.add('d2l-fullpage', function(editor) {
 
-	// specifically pull in 0.5.0 containing Lato font
+	/* caution: do not remove the specific check for lato or this URL, because user
+	authored content may require it as long as we support Lato in the editor, and
+	removing Lato from the editor means disruptive change when editing existing content */
+
 	const fontsUrl = 'https://s.brightspace.com/lib/fonts/0.5.0/fonts.css';
 
 	editor.on('GetContent', (e) => {

--- a/demo/htmleditor.html
+++ b/demo/htmleditor.html
@@ -59,7 +59,7 @@
 
 			<d2l-demo-snippet>
 				<template>
-					<d2l-htmleditor id="full-page" full-page full-page-font-color="#494c4e" full-page-font-family="verdana, sans-serif" full-page-font-size="12px"></d2l-htmleditor>
+					<d2l-htmleditor id="full-page" full-page full-page-font-color="#494c4e" full-page-font-family="lato, sans-serif" full-page-font-size="14pt"></d2l-htmleditor>
 					<script>
 						document.querySelector('#full-page').html = window.getDemoHtml('#default-html');
 					</script>

--- a/htmleditor.js
+++ b/htmleditor.js
@@ -1,8 +1,9 @@
 import '@brightspace-ui/core/components/alert/alert.js';
 import '@brightspace-ui/core/components/html-block/html-block.js';
-import './components/quicklink.js';
 import './components/equation.js';
+import './components/fullpage.js';
 import './components/preview.js';
+import './components/quicklink.js';
 import './components/wordcount.js';
 import 'tinymce/tinymce.js';
 import 'tinymce/icons/default/icons.js';
@@ -361,7 +362,7 @@ class HtmlEditor extends SkeletonMixin(ProviderMixin(Localizer(RtlMixin(LitEleme
 				},
 				mentions_selector: 'span[data-mentions-id]',
 				object_resizing : true,
-				plugins: `a11ychecker ${this.autoSave ? 'autosave' : ''} advtable autolink charmap advcode directionality emoticons ${this.fullPage ? 'fullpage' : ''} fullscreen hr image ${this.pasteLocalImages ? 'imagetools' : ''} lists link ${(this.mentions && D2L.LP) ? 'mentions' : ''} powerpaste ${this._context ? 'd2l-preview' : 'preview'} quickbars table textpattern d2l-equation d2l-image d2l-isf d2l-quicklink d2l-wordcount`,
+				plugins: `a11ychecker ${this.autoSave ? 'autosave' : ''} advtable autolink charmap advcode directionality emoticons ${this.fullPage ? 'fullpage d2l-fullpage' : ''} fullscreen hr image ${this.pasteLocalImages ? 'imagetools' : ''} lists link ${(this.mentions && D2L.LP) ? 'mentions' : ''} powerpaste ${this._context ? 'd2l-preview' : 'preview'} quickbars table textpattern d2l-equation d2l-image d2l-isf d2l-quicklink d2l-wordcount`,
 				quickbars_insert_toolbar: false,
 				relative_urls: false,
 				resize: true,

--- a/htmleditor.js
+++ b/htmleditor.js
@@ -80,6 +80,10 @@ if (!tinymceLangs.includes(documentLang)) {
 const pathFromUrl = url => url.substring(0, url.lastIndexOf('/'));
 const baseImportPath = pathFromUrl(import.meta.url);
 
+const fullPageStyles = css`
+	@import url("https://s.brightspace.com/lib/fonts/0.5.0/fonts.css");
+`.cssText;
+
 const contentFragmentStyles = css`
 	@import url("https://s.brightspace.com/lib/fonts/0.5.0/fonts.css");
 	html {
@@ -315,7 +319,7 @@ class HtmlEditor extends SkeletonMixin(ProviderMixin(Localizer(RtlMixin(LitEleme
 				browser_spellcheck: !this.noSpellchecker,
 				convert_urls: false,
 				content_css: `${baseImportPath}/tinymce/skins/content/default/content.css`,
-				content_style: this.fullPage ? isfStyles : `${contentFragmentStyles} ${isfStyles}`,
+				content_style: this.fullPage ? `${fullPageStyles} ${isfStyles}` : `${contentFragmentStyles} ${isfStyles}`,
 				contextmenu: 'image imagetools table',
 				directionality: this.dir ? this.dir : 'ltr',
 				elementpath: false,


### PR DESCRIPTION
This required a lot of playing around, trying to get the various scenarios working. It turned out to be not too bad, but the process of arriving at this code was a little frustrating. This code effectively ensures that when we get the HTML from the editor, it will contain the [Lato stylesheet](https://s.brightspace.com/lib/fonts/0.5.0/fonts.css) reference if the HTML contains a reference to Lato.  I think this change covers the cases where:

* user selects Lato from toolbar dropdown
* user pastes content containing Lato
* user starts a new document with the full page font specifying Lato
* user adds Lato font in source code view

The content that is saved is updated via the `d2l-fullpage` plugin that wires up to tinyMCE's `GetContent` event.  The design view shows Lato if used because the stylesheet is always included in the tinyMCE content styles configuration.

This does not detect the scenario where Lato is used in an external stylesheet, but I think in that case, that external stylesheet should just include an `@import` statement to include the font.

**Important**: by allowing the user to select Lato specifically, we are effectively committing to supporting Lato forever in user-authored content. If we ever change fonts, we will have a new fonts.css url (ex. 0.6.0), we would be adding another check like this one (not removing this one).