### PR TITLE
Ensure focus goes to content iframe after D2L dialogs are closed

### DIFF
--- a/components/equation.js
+++ b/components/equation.js
@@ -50,11 +50,13 @@ tinymce.PluginManager.add('d2l-equation', function(editor) {
 			dialog.mathML = decodeURIComponent(contextNode.attributes.getNamedItem('data-d2l-mathml').value);
 		}
 
+		if (editor.selection) dialog.bookmark = editor.selection.getBookmark();
 		dialog.type = editorType;
 		dialog.opened = true;
 		dialog.addEventListener('d2l-htmleditor-equation-dialog-close', (e) => {
 			const html = e.detail.html;
 			if (html) editor.execCommand('mceInsertContent', false, html);
+			root.host.focus();
 		}, { once: true });
 
 	};
@@ -236,7 +238,8 @@ class EditorDialog extends LitElement {
 			const result = await openDialogWithParam(
 				getComposedActiveElement(),
 				'/d2l/lp/math/createeditor',
-				{ mathml: this.mathML, editorType: this.type }
+				{ mathml: this.mathML, editorType: this.type },
+				{ byPassOpenerFocus: true }
 			);
 
 			this.opened = false;

--- a/components/equation.js
+++ b/components/equation.js
@@ -50,7 +50,6 @@ tinymce.PluginManager.add('d2l-equation', function(editor) {
 			dialog.mathML = decodeURIComponent(contextNode.attributes.getNamedItem('data-d2l-mathml').value);
 		}
 
-		if (editor.selection) dialog.bookmark = editor.selection.getBookmark();
 		dialog.type = editorType;
 		dialog.opened = true;
 		dialog.addEventListener('d2l-htmleditor-equation-dialog-close', (e) => {

--- a/components/image.js
+++ b/components/image.js
@@ -230,9 +230,9 @@ class FileSelectorDialog extends RequesterMixin(LitElement) {
 						{ IsEnabled: true, IsPrimary: true, Key: 'BTN_next', ResponseType: 1, Param: 'next', Text: 'Insert' },
 						{ IsEnabled: true, IsPrimary: false, Key: 'BTN_back', ResponseType: 1, Param: 'back', Text: 'Back' },
 						{ IsEnabled: true, IsPrimary: false, ResponseType: 0, Text: 'Cancel' }
-					]
-				},
-				{ byPassOpenerFocus: true }
+					],
+					byPassOpenerFocus: true
+				}
 			);
 
 			this.opened = false;

--- a/components/image.js
+++ b/components/image.js
@@ -149,6 +149,7 @@ tinymce.PluginManager.add('d2l-image', function(editor) {
 				tempImg.style.maxWidth = '100%';
 
 				editor.execCommand('mceInsertContent', false, tempImg.outerHTML);
+				root.host.focus();
 
 			}, { once: true });
 
@@ -230,7 +231,8 @@ class FileSelectorDialog extends RequesterMixin(LitElement) {
 						{ IsEnabled: true, IsPrimary: false, Key: 'BTN_back', ResponseType: 1, Param: 'back', Text: 'Back' },
 						{ IsEnabled: true, IsPrimary: false, ResponseType: 0, Text: 'Cancel' }
 					]
-				}
+				},
+				{ byPassOpenerFocus: true }
 			);
 
 			this.opened = false;

--- a/components/isf.js
+++ b/components/isf.js
@@ -44,6 +44,7 @@ tinymce.PluginManager.add('d2l-isf', function(editor) {
 			dialog.addEventListener('d2l-htmleditor-isf-dialog-close', (e) => {
 				const html = e.detail.html;
 				if (html) editor.execCommand('mceInsertContent', false, html);
+				root.host.focus();
 			}, { once: true });
 
 		}
@@ -434,7 +435,8 @@ class IsfDialog extends RequesterMixin(LitElement) {
 					responseDataKey: 'itemSource',
 					width: 975,
 					height: 650,
-					buttons: [{ IsEnabled: true, IsPrimary: true, Key: 'BTN_next', ResponseType: 1, Param: 'next', Text: 'Insert' }]
+					buttons: [{ IsEnabled: true, IsPrimary: true, Key: 'BTN_next', ResponseType: 1, Param: 'next', Text: 'Insert' }],
+					byPassOpenerFocus: true
 				}
 			);
 

--- a/components/lms-adapter.js
+++ b/components/lms-adapter.js
@@ -82,6 +82,7 @@ export async function openLegacyDialog(opener, location, settings) {
 			const result = await dialogService.openLegacy(
 				location,
 				{
+					byPassOpenerFocus: settings.byPassOpenerFocus,
 					PreferredSize: {
 						PreferredHeight: settings.height,
 						PreferredWidth: settings.width
@@ -111,7 +112,8 @@ export async function openLegacyDialog(opener, location, settings) {
 				null,
 				settings.buttons,
 				false,
-				null
+				null,
+				settings.byPassOpenerFocus
 			);
 
 			dialogResult.AddReleaseListener(resolve);

--- a/components/preview.js
+++ b/components/preview.js
@@ -30,6 +30,9 @@ tinymce.PluginManager.add('d2l-preview', function(editor) {
 			dialog.opener = root.host;
 			dialog.opened = true;
 
+			dialog.addEventListener('d2l-htmleditor-preview-dialog-close', () => {
+				root.host.focus();
+			}, { once: true });
 		}
 	});
 
@@ -81,10 +84,17 @@ class PreviewDialog extends RequesterMixin(LitElement) {
 			await openDialogWithParam(
 				getComposedActiveElement(),
 				`/d2l/lp/htmleditor/${this._fullPage ? 'fullpagepreview' : 'inlinepreview'}?ou=${this._orgUnitId}`,
-				{ editor: this.htmlInfo, filter: this._noFilter ? 0 : 1 }
+				{ editor: this.htmlInfo, filter: this._noFilter ? 0 : 1 },
+				{ byPassOpenerFocus: true }
 			);
 
 			this.opened = false;
+
+			this.dispatchEvent(new CustomEvent(
+				'd2l-htmleditor-preview-dialog-close', {
+					bubbles: true
+				}
+			));
 
 		}
 

--- a/components/quicklink.js
+++ b/components/quicklink.js
@@ -51,7 +51,7 @@ tinymce.PluginManager.add('d2l-quicklink', function(editor) {
 				}
 
 				root.host.focus();
-				
+
 			}, { once: true });
 
 		}

--- a/components/quicklink.js
+++ b/components/quicklink.js
@@ -49,6 +49,9 @@ tinymce.PluginManager.add('d2l-quicklink', function(editor) {
 					}
 					editor.execCommand('mceInsertContent', false, html);
 				}
+
+				root.host.focus();
+				
 			}, { once: true });
 
 		}
@@ -150,7 +153,8 @@ class QuicklinkDialog extends RequesterMixin(LitElement) {
 
 					const selectResult = D2L.LP.Web.UI.Desktop.MasterPages.Dialog.Open(
 						getComposedActiveElement(),
-						selectUrl
+						selectUrl,
+						{ byPassOpenerFocus: true }
 					);
 
 					selectResult.AddReleaseListener(resolve);

--- a/components/wordcount.js
+++ b/components/wordcount.js
@@ -113,6 +113,15 @@ tinymce.PluginManager.add('d2l-wordcount', function(editor) {
 				countButton.textContent = localize(getButtonLangTerm(countType, isSelection), { count: count });
 			}
 		});
+
+		dialog.addEventListener('d2l-dialog-close', () => {
+			dialog.counts = {};
+			dialog.opened = false;
+			dialog.selectedCounts = {};
+
+			root.host.focus();
+
+		}, { once: true });
 	};
 
 	editor.ui.registry.addButton('d2l-wordcount', {
@@ -225,7 +234,7 @@ class WordCountDialog extends RequesterMixin(RtlMixin(LitElement)) {
 
 	render() {
 		return html`
-			<d2l-dialog width="500" title-text="${this._localize('wordcount.dialog.title')}" ?opened="${this.opened}" @d2l-dialog-close=${(this._handleDialogClosed)}>
+			<d2l-dialog width="500" title-text="${this._localize('wordcount.dialog.title')}" ?opened="${this.opened}">
 				${this._renderWordCountInfo()}
 				<div slot="footer">
 					<d2l-button primary data-dialog-action>${this._localize('wordcount.dialog.closebutton')}</d2l-button>
@@ -244,12 +253,6 @@ class WordCountDialog extends RequesterMixin(RtlMixin(LitElement)) {
 			default:
 				return this._localize('wordcount.footerselectorlabel.nocount');
 		}
-	}
-
-	_handleDialogClosed() {
-		this.counts = {};
-		this.opened = false;
-		this.selectedCounts = {};
 	}
 
 	_handleSelectCharacterCountOption() {


### PR DESCRIPTION
Dependent on this LMS PR: https://github.com/Brightspace/lms/pull/7021

This PR adds logic to our custom dialogs to put focus back on the editor after they're closed. We also need to specify the `byPassOpenerFocus` setting on the dialogs when we open them, otherwise when the dialog close event finishes processing (after our code has already executed), focus gets placed back on the opener (which is the toolbar button).