### PR TITLE
When in an FRA context, specify the document base URL as the Valence host and ensure we're using that to construct images

### DIFF
--- a/components/image.js
+++ b/components/image.js
@@ -141,14 +141,10 @@ tinymce.PluginManager.add('d2l-image', function(editor) {
 					)
 				);
 
-				const tempImg = document.createElement('img');
-				tempImg.setAttribute('src', src);
-				tempImg.setAttribute('alt', e.detail.IsDecorative ? '' : e.detail.ImageAlt);
-				tempImg.setAttribute('title', e.detail.IsDecorative ? '' : e.detail.ImageAlt);
-				tempImg.setAttribute('data-d2l-editor-default-img-style', 'true');
-				tempImg.style.maxWidth = '100%';
+				const altText = e.detail.IsDecorative ? '' : e.detail.ImageAlt;
+				const imgHtml = `<img src="${src}" alt="${altText}" title="${altText}" data-d2l-editor-default-img-style>`;
 
-				editor.execCommand('mceInsertContent', false, tempImg.outerHTML);
+				editor.execCommand('mceInsertContent', false, imgHtml/*tempImg.outerHTML*/);
 				root.host.focus();
 
 			}, { once: true });

--- a/components/image.js
+++ b/components/image.js
@@ -142,9 +142,9 @@ tinymce.PluginManager.add('d2l-image', function(editor) {
 				);
 
 				const altText = e.detail.IsDecorative ? '' : e.detail.ImageAlt;
-				const imgHtml = `<img src="${src}" alt="${altText}" title="${altText}" data-d2l-editor-default-img-style>`;
+				const imgHtml = `<img src="${src}" alt="${altText}" title="${altText}" data-d2l-editor-default-img-style style="max-width: 100%;">`;
 
-				editor.execCommand('mceInsertContent', false, imgHtml/*tempImg.outerHTML*/);
+				editor.execCommand('mceInsertContent', false, imgHtml);
 				root.host.focus();
 
 			}, { once: true });

--- a/htmleditor-mixin.js
+++ b/htmleditor-mixin.js
@@ -306,6 +306,11 @@ export const HtmlEditorMixin = superclass => class extends Localizer(RtlMixin(Pr
 			autosave_retention: '0s'
 		};
 
+		const documentConfig = {};
+		if (this._fraContext && this._context && this._context.host) {
+			documentConfig.document_base_url = this._context.host;
+		}
+
 		/*
 		paste_preprocess: function(plugin, data) {
 			// Stops Paste plugin from converting pasted image links to image
@@ -456,6 +461,7 @@ export const HtmlEditorMixin = superclass => class extends Localizer(RtlMixin(Pr
 			valid_elements: '*[*]',
 			width: this.width,
 			...autoSaveConfig,
+			...documentConfig,
 			...fullPageConfig,
 			...powerPasteConfig
 		});

--- a/htmleditor-mixin.js
+++ b/htmleditor-mixin.js
@@ -307,7 +307,7 @@ export const HtmlEditorMixin = superclass => class extends Localizer(RtlMixin(Pr
 		};
 
 		const documentConfig = {};
-		if (this._fraContext && this._context && this._context.host) {
+		if (this._context && this._context.host) {
 			documentConfig.document_base_url = this._context.host;
 		}
 


### PR DESCRIPTION
Inserting an image in an FRA context currently fails because the current workflow assumes the image src is going to match the FRA's host domain (the CDN). We should set `document_base_url` in TinyMCE's init to match the Valence host if we're in an FRA context to get around this problem.