### PR TITLE
Container divs should inherit the height of their parents when the HTML editor has a percentage height

### DIFF
--- a/htmleditor-mixin.js
+++ b/htmleditor-mixin.js
@@ -479,7 +479,7 @@ export const HtmlEditorMixin = superclass => class extends Localizer(RtlMixin(Pr
 			'd2l-htmleditor-tinymce': true,
 			'd2l-htmleditor-tinymce-percentage-height': this.height.includes('%')
 		};
-		
+
 		const textAreaClasses = {
 			'd2l-htmleditor-no-tinymce': !isShadowDOMSupported
 		};

--- a/htmleditor-mixin.js
+++ b/htmleditor-mixin.js
@@ -128,7 +128,9 @@ export const HtmlEditorMixin = superclass => class extends Localizer(RtlMixin(Pr
 			.d2l-htmleditor-no-tinymce {
 				display: none;
 			}
-
+			.d2l-htmleditor-tinymce-percentage-height {
+				height: inherit;
+			}
 			/* stylelint-disable selector-class-pattern */
 			:host(.tox-fullscreen) {
 				position: fixed;
@@ -473,12 +475,17 @@ export const HtmlEditorMixin = superclass => class extends Localizer(RtlMixin(Pr
 	}
 
 	_render() {
+		const containerClasses = {
+			'd2l-htmleditor-tinymce': true,
+			'd2l-htmleditor-tinymce-percentage-height': this.height.includes('%')
+		};
+		
 		const textAreaClasses = {
 			'd2l-htmleditor-no-tinymce': !isShadowDOMSupported
 		};
 
 		return html`
-			<div class="d2l-htmleditor-tinymce">
+			<div class="${classMap(containerClasses)}">
 				<textarea id="${this._editorId}" class="${classMap(textAreaClasses)}" aria-hidden="true" tabindex="-1">${this._html}</textarea>
 			</div>
 			${!isShadowDOMSupported ? html`<d2l-alert>Web Components are not supported in this browser. Upgrade or switch to a newer browser to use the shiny new HtmlEditor.</d2l-alert>` : ''}

--- a/htmleditor.js
+++ b/htmleditor.js
@@ -50,6 +50,9 @@ class HtmlEditor extends HtmlEditorMixin(SkeletonMixin(LitElement)) {
 			:host([hidden]) {
 				display: none;
 			}
+			.d2l-htmleditor-percentage-height {
+				height: inherit;
+			}
 			.d2l-htmleditor-inline-container .d2l-htmleditor-container {
 				display: none;
 			}
@@ -139,9 +142,15 @@ class HtmlEditor extends HtmlEditorMixin(SkeletonMixin(LitElement)) {
 
 	_renderEditor() {
 
+		const containerClasses = {
+			'd2l-htmleditor-container': true,
+			'd2l-skeletize': true,
+			'd2l-htmleditor-percentage-height': super.height.includes('%')
+		};
+
 		return html`
 			${this.label && !this.labelHidden ? html`<span class="d2l-input-label d2l-skeletize" aria-hidden="true">${this.label}</span>` : ''}
-			<div class="d2l-htmleditor-container d2l-skeletize">
+			<div class="${classMap(containerClasses)}">
 				${this._render()}
 			</div>
 		`;
@@ -150,13 +159,17 @@ class HtmlEditor extends HtmlEditorMixin(SkeletonMixin(LitElement)) {
 
 	_renderInlineEditor() {
 
+		const hasPercentageHeight = this.height.includes('%');
+
 		const containerClasses = {
 			'd2l-htmleditor-inline-container': true,
+			'd2l-htmleditor-percentage-height': hasPercentageHeight,
 			'd2l-is-editing': this._isEditing
 		};
 
 		const htmlBlockClasses = {
 			'd2l-htmleditor-inline-html-block': true,
+			'd2l-htmleditor-percentage-height': hasPercentageHeight,
 			'd2l-input': true,
 			'd2l-input-focus': this._isInlineEditButtonFocusing
 		};


### PR DESCRIPTION
When the editor is given a height in percentage, it (by default) will size down to near zero (50-something pixels in my testing), since its container divs don't have a fixed height. If this is the case, we want to set the container divs to inherit their parents' height to ensure the editor has something to size itself against.