### PR TITLE
DE42844 - Add save method to HTML editor

### DIFF
--- a/htmleditor-mixin.js
+++ b/htmleditor-mixin.js
@@ -263,6 +263,11 @@ export const HtmlEditorMixin = superclass => class extends Localizer(RtlMixin(Pr
 		return (editor && editor.isDirty());
 	}
 
+	save() {
+		const editor = tinymce.EditorManager.get(this._editorId);
+		if (editor) editor.save();
+	}
+
 	_getMinHeight() {
 		const defaultMinHeight = 300;
 		const splitPosition = this.height.search(/\D/);


### PR DESCRIPTION
For autosave to function properly, we need a mechanism to "save" the contents of the editor (really it just propagates any contents to the `textarea`). Otherwise, workflows that submit the HTML from the editor will still prompt an autosave warning.