### PR TITLE
Fix inverted logic in word count dialog calculations

### DIFF
--- a/wordcount/test/testcases.js
+++ b/wordcount/test/testcases.js
@@ -6,6 +6,7 @@ const textWithExtraWhiteSpace = `Some
 const textWithLeadingAndTrailingWhiteSpace = `
 	   Some test text here
 	   `;
+const textWithTrailingSpace = 'Some test text here ';
 const textWithNoCharacters = '';
 const textWithOnlyMultipleWhiteSpaceCharacters = `
 	`;
@@ -35,6 +36,11 @@ export const testCases = [
 		name: 'Text with leading and trailing whitespace',
 		text: textWithLeadingAndTrailingWhiteSpace,
 		expectedCounts: new Counts(4, 29, 16)
+	},
+	{
+		name: 'Text with trailing space character',
+		text: textWithTrailingSpace,
+		expectedCounts: new Counts(4, 20, 16)
 	},
 	{
 		name: 'Text with no characters',

--- a/wordcount/wordcount.js
+++ b/wordcount/wordcount.js
@@ -12,17 +12,10 @@ export function countAll(text) {
 	let charCount = 0;
 	let wordCount = 0;
 	for (let i = 0; i < text.length; i++) {
-		if (!whiteSpaceChars.includes(text.charAt(i))) {
-			charCount++;
+		if (whiteSpaceChars.includes(text.charAt(i))) continue;
 
-			if (i === 0) wordCount++;
-
-			continue;
-		}
-
-		if (i === 0 || whiteSpaceChars.includes(text.charAt(i - 1))) continue;
-
-		wordCount++;
+		if (i === 0 || whiteSpaceChars.includes(text.charAt(i - 1))) wordCount++;
+		charCount++;
 	}
 
 	return {


### PR DESCRIPTION
Turns out the logic for calculating the word count in the dialog was a bit backwards, leading to trailing spaces being interpreted as an extra word. I've switched over the logic to be the same as the specific word count function to avoid any future confusion. I also added a new test case to capture this specific scenario. I can confirm that it fails before this change and passes afterwards.