### PR TITLE
Replace save() function with isDirty getter and setter

### DIFF
--- a/htmleditor-mixin.js
+++ b/htmleditor-mixin.js
@@ -216,6 +216,16 @@ export const HtmlEditorMixin = superclass => class extends Localizer(RtlMixin(Pr
 		}
 	}
 
+	get isDirty() {
+		const editor = tinymce.EditorManager.get(this._editorId);
+		return (editor && editor.isDirty());
+	}
+
+	set isDirty(isDirty) {
+		const editor = tinymce.EditorManager.get(this._editorId);
+		if (editor) editor.setDirty(isDirty);
+	}
+
 	async firstUpdated(changedProperties) {
 		super.firstUpdated(changedProperties);
 
@@ -256,16 +266,6 @@ export const HtmlEditorMixin = superclass => class extends Localizer(RtlMixin(Pr
 
 	get initializationComplete() {
 		return this._initializationComplete;
-	}
-
-	get isDirty() {
-		const editor = tinymce.EditorManager.get(this._editorId);
-		return (editor && editor.isDirty());
-	}
-
-	save() {
-		const editor = tinymce.EditorManager.get(this._editorId);
-		if (editor) editor.save();
 	}
 
 	_getMinHeight() {


### PR DESCRIPTION
We're not really using the functionality that `save()` provided us anymore (pushing content to the editor's internal `textarea`), since form submissions don't cross the shadowDOM boundary and trigger TinyMCE's form submission logic. So, may as well just expose a setter on `isDirty` that does only the bits we want and makes it more clear what's actually happening.